### PR TITLE
Removing all use of v62.

### DIFF
--- a/rauzy/algorithme1/BDTs.v
+++ b/rauzy/algorithme1/BDTs.v
@@ -56,7 +56,7 @@ Lemma neq_vars_neq_BDTs :
 Proof.
 unfold not in |- *.
 intros i1 i2 Di1i2 h1 h2 l1 l2 H_absurde.
-apply Di1i2; injection H_absurde; trivial with v62.
+apply Di1i2; injection H_absurde; trivial with arith.
 Qed.
 Hint Resolve neq_vars_neq_BDTs.
 
@@ -67,7 +67,7 @@ Lemma neq_left_neq_BDTs :
 Proof.
 unfold not in |- *.
 intros i1 i2 Di1i2 h1 h2 l1 l2 H_absurde.
-apply Di1i2; injection H_absurde; trivial with v62.
+apply Di1i2; injection H_absurde; trivial with arith.
 Qed.
 Hint Resolve neq_left_neq_BDTs.
 
@@ -78,18 +78,18 @@ Lemma neq_right_neq_BDTs :
 Proof.
 unfold not in |- *.
 intros i1 i2 Di1i2 h1 h2 l1 l2 H_absurde.
-apply Di1i2; injection H_absurde; trivial with v62.
+apply Di1i2; injection H_absurde; trivial with arith.
 Qed.
 Hint Resolve neq_right_neq_BDTs.
 
 Lemma eq_BDT_decidable : forall t1 t2 : BDT, {t1 = t2} + {t1 <> t2}.
 Proof.
-simple induction t1; simple induction t2; auto with v62.
+simple induction t1; simple induction t2; auto with arith.
 intros n' y' H1 y0' H2.
 elim (eq_nat_dec n n'); intro H_var; elim (H y'); intro H_left; elim (H0 y0');
- intro H_right; auto with v62.
+ intro H_right; auto with arith.
 (* case equal *)
-elim H_right; elim H_left; elim H_var; left; trivial with v62.
+elim H_right; elim H_left; elim H_var; left; trivial with arith.
 Qed.
 
 Lemma Components_eq_nodes_eq :
@@ -99,7 +99,7 @@ Lemma Components_eq_nodes_eq :
  h1 = h2 -> l1 = l2 -> Node i1 h1 l1 = Node i2 h2 l2.
 Proof.
 intros i1 i2 Hi h1 h2 l1 l2 Hh Hl.
-elim Hi; elim Hh; elim Hl; trivial with v62.
+elim Hi; elim Hh; elim Hl; trivial with arith.
 Qed.
 
 
@@ -125,7 +125,7 @@ Hint Resolve dim_zero dim_one dim_node.
 
 Lemma dim_Dim : forall (d : nat) (bdt : BDT), dim bdt d -> d = Dim bdt.
 Proof.
-simple induction 1; simpl in |- *; auto with v62.
+simple induction 1; simpl in |- *; auto with arith.
 Qed.
 Hint Resolve dim_Dim.
 
@@ -157,15 +157,15 @@ Definition Choice (B : BDT) (i : nat) (b : bool) : BDT :=
 Lemma Choice_invariant :
  forall (t : BDT) (i : nat), i > Dim t -> forall b : bool, t = Choice t i b.
 Proof.
-simple induction t; try trivial with v62.
+simple induction t; try trivial with arith.
 intros d bh Hh bl Hl i Hi.
-unfold Choice in |- *; elim (Compar i d); trivial with v62.
+unfold Choice in |- *; elim (Compar i d); trivial with arith.
 intro H_absurde.
-absurd (i > Dim (Node d bh bl)); trivial with v62.
-simpl in |- *; rewrite H_absurde; trivial with v62.
+absurd (i > Dim (Node d bh bl)); trivial with arith.
+simpl in |- *; rewrite H_absurde; trivial with arith.
 intro H_absurde.
-absurd (i > Dim (Node d bh bl)); trivial with v62.
-simpl in |- *; auto with v62.
+absurd (i > Dim (Node d bh bl)); trivial with arith.
+simpl in |- *; auto with arith.
 Qed.
 
 
@@ -174,9 +174,9 @@ Lemma Choice_left :
 Proof.
 intros i bh bl.
 unfold Choice in |- *; elim (Compar i i);
- [ intro; absurd (i > i); trivial with v62
- | trivial with v62
- | intro; absurd (i > i); trivial with v62 ].  
+ [ intro; absurd (i > i); trivial with arith
+ | trivial with arith
+ | intro; absurd (i > i); trivial with arith ].  
 Qed.
 
 
@@ -186,9 +186,9 @@ Lemma Choice_right :
 Proof.
 intros i bh bl.
 unfold Choice in |- *; elim (Compar i i);
- [ intro; absurd (i > i); trivial with v62
- | trivial with v62
- | intro; absurd (i > i); trivial with v62 ]. 
+ [ intro; absurd (i > i); trivial with arith
+ | trivial with arith
+ | intro; absurd (i > i); trivial with arith ]. 
 Qed.
 
 
@@ -220,7 +220,7 @@ Definition inv_OBDT_dim (bdt : BDT) : Prop :=
 
 Lemma p_inv_OBDT_dim : forall bdt : BDT, OBDT bdt -> inv_OBDT_dim bdt.
 Proof.
-simple induction 1; simpl in |- *; auto with v62.
+simple induction 1; simpl in |- *; auto with arith.
 Qed.
 Hint Resolve p_inv_OBDT_dim.
 
@@ -229,7 +229,7 @@ Lemma dim_node_dim_sons :
  OBDT (Node i bh bl) -> i > Dim bh /\ i > Dim bl.
 Proof.
 intros i bh bl Node_ordered.
-change (inv_OBDT_dim (Node i bh bl)) in |- *; auto with v62.
+change (inv_OBDT_dim (Node i bh bl)) in |- *; auto with arith.
 Qed.
 
 
@@ -240,7 +240,7 @@ Proof.
 intros i bh bl H.
 simpl in |- *.
 elim (dim_node_dim_sons i bh bl H); intros Hh Hl.
-apply gt_le_trans with (m := Dim bh); auto with v62.
+apply gt_le_trans with (m := Dim bh); auto with arith.
 Qed.
 
 
@@ -254,9 +254,9 @@ Lemma Dim_gt_O_node_decomposition :
  forall b : BDT, OBDT b -> Dim b > 0 -> node_decomposition b.
 Proof.
 simple induction b;
- [ simpl in |- *; intros; absurd (0 > 0); auto with v62
- | simpl in |- *; intros; absurd (0 > 0); auto with v62
- | intros i h Hh l Hl HO Hd; apply node_exist with i l h; trivial with v62 ].
+ [ simpl in |- *; intros; absurd (0 > 0); auto with arith
+ | simpl in |- *; intros; absurd (0 > 0); auto with arith
+ | intros i h Hh l Hl HO Hd; apply node_exist with i l h; trivial with arith ].
 Qed.
 
 
@@ -273,7 +273,7 @@ Definition inv_OBDT_order (bdt : BDT) : Prop :=
 
 Lemma p_inv_OBDT_order : forall bdt : BDT, OBDT bdt -> inv_OBDT_order bdt.
 Proof.
-simple induction 1; simpl in |- *; auto with v62.
+simple induction 1; simpl in |- *; auto with arith.
 Qed.
 Hint Resolve p_inv_OBDT_order.
 
@@ -291,7 +291,7 @@ Definition inv_OBDT_neq (bdt : BDT) : Prop :=
 
 Lemma p_inv_OBDT_neq : forall bdt : BDT, OBDT bdt -> inv_OBDT_neq bdt.
 Proof.
-simple induction 1; simpl in |- *; auto with v62.
+simple induction 1; simpl in |- *; auto with arith.
 Qed.
 Hint Resolve p_inv_OBDT_neq.
 
@@ -300,7 +300,7 @@ Lemma ordered_node_neq_sons :
  forall (i : nat) (bh bl : BDT), OBDT (Node i bh bl) -> bh <> bl.
 Proof.
 intros i bh bl Node_ordered.
-change (inv_OBDT_neq (Node i bh bl)) in |- *; auto with v62.
+change (inv_OBDT_neq (Node i bh bl)) in |- *; auto with arith.
 Qed.
 
 
@@ -313,30 +313,30 @@ apply deMorgan_or_not.
 unfold not in |- *; simple induction 1; intros H1 H2; clear H.  
 absurd (bh = bl :>BDT);
  [ exact (ordered_node_neq_sons i bh bl HO)
- | rewrite H1; rewrite H2; trivial with v62 ].
+ | rewrite H1; rewrite H2; trivial with arith ].
 Qed.
 
 Lemma ordered_node_ordered_sons :
  forall (i : nat) (bh bl : BDT), OBDT (Node i bh bl) -> OBDT bh /\ OBDT bl.
 Proof.
 intros i bh bl Node_ordered.
-change (inv_OBDT_order (Node i bh bl)) in |- *; auto with v62.
+change (inv_OBDT_order (Node i bh bl)) in |- *; auto with arith.
 Qed.
 
 Lemma Ordered_node_ordered_restr :
  forall t : BDT,
  OBDT t -> forall i : nat, Dim t <= i -> forall b : bool, OBDT (Choice t i b).
 Proof.
-simple induction 1; [ auto with v62 | auto with v62 | idtac ].
+simple induction 1; [ auto with arith | auto with arith | idtac ].
 clear H t.
 intros bl bh H1l H2l H1h H2h i H1i H2i bl_neq_bh j Hj.
 unfold Choice in |- *; elim (Compar j i);
- [ auto with v62
+ [ auto with arith
  |  (* Case j > i *)
-    intro; simple induction b0; trivial with v62
+    intro; simple induction b0; trivial with arith
  |  (* Case j = i *)
     intro H_absurd;  (* Case i > j *)
-    absurd (Dim (Node i bl bh) > j); auto with v62 ].
+    absurd (Dim (Node i bl bh) > j); auto with arith ].
 Qed.
 
 Lemma Choice_dim_decrease :
@@ -344,16 +344,16 @@ Lemma Choice_dim_decrease :
  OBDT t -> Dim t > 0 -> forall b : bool, Dim t > Dim (Choice t (Dim t) b).
 Proof.
 simple induction 1;
- [ simpl in |- *; intro H_abs; absurd (0 > 0); auto with v62
- | simpl in |- *; intro H_abs; absurd (0 > 0); auto with v62
+ [ simpl in |- *; intro H_abs; absurd (0 > 0); auto with arith
+ | simpl in |- *; intro H_abs; absurd (0 > 0); auto with arith
  | idtac ].
 clear H t.
 intros bl bh HOl Hrecl HOh Hrech i Hi1 Hi2 bh_neq_bl H.
 simpl in |- *.
 elim (Compar i i);
- [ intro H_abs; absurd (i > i); auto with v62
+ [ intro H_abs; absurd (i > i); auto with arith
  | intro Htriv; simple induction b; assumption
- | intro H_abs; absurd (i > i); auto with v62 ].
+ | intro H_abs; absurd (i > i); auto with arith ].
 Qed.
 
 
@@ -382,18 +382,18 @@ elim (Choice_invariant t2 (Maxdim t1 t2));
  | unfold Maxdim in |- *; elim (gt_Max (Dim t1) (Dim t2)); try assumption ].
 apply Max_mon_left; try assumption.
 unfold Maxdim in |- *; elim (gt_Max (Dim t1) (Dim t2)); try assumption.
-apply Choice_dim_decrease; trivial with v62.
+apply Choice_dim_decrease; trivial with arith.
 (*-----  Case  Dim(t1) = Dim(t2) -----*)
 intros D1_eq_D2 b.
 rewrite Def_i.
 unfold Maxdim at 1 2 in |- *.
 apply Max_mon_middle.
-unfold Maxdim in |- *; elim (eq_Max (Dim t1) (Dim t2)); trivial with v62.
-apply Choice_dim_decrease; trivial with v62.
+unfold Maxdim in |- *; elim (eq_Max (Dim t1) (Dim t2)); trivial with arith.
+apply Choice_dim_decrease; trivial with arith.
 unfold Maxdim in |- *; elim (Max_sym (Dim t2) (Dim t1)).
 elim (eq_Max (Dim t2) (Dim t1));
- [ apply Choice_dim_decrease; trivial with v62
- | symmetry  in |- *; trivial with v62 ].
+ [ apply Choice_dim_decrease; trivial with arith
+ | symmetry  in |- *; trivial with arith ].
 (*-----  Case Dim(t1) < Dim(t2) ------*)
 intros D2_gt_D1 b.
 rewrite Def_i.
@@ -406,7 +406,7 @@ rewrite (Max_sym (Dim t1) (Dim t2)).
 elim (gt_Max (Dim t2) (Dim t1)); try assumption.
 unfold Maxdim in |- *.
 apply Max_mon_right; try assumption.
-apply Choice_dim_decrease; trivial with v62.
+apply Choice_dim_decrease; trivial with arith.
 Qed.
 
 
@@ -428,11 +428,11 @@ rewrite (Choice_left i1 h1 l1).
 rewrite (Choice_invariant (Node i2 h2 l2) i1 Hi true).
 pattern i1 at 3 4 in |- *; rewrite (gt_Max i1 i2 Hi).
 apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62 ].
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith ].
 Qed.
 
 
@@ -445,11 +445,11 @@ rewrite (Choice_right i1 h1 l1).
 rewrite (Choice_invariant (Node i2 h2 l2) i1 Hi false).
 pattern i1 at 3 4 in |- *; rewrite (gt_Max i1 i2 Hi).
 apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62 ].
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith ].
 Qed.
 
 Lemma Decrease_n1n2_h1h2 : i1 = i2 -> Max i1 i2 > Max (Dim h1) (Dim h2).
@@ -461,12 +461,12 @@ rewrite (Choice_left i2 h2 l2).
 pattern i1 at 3 in |- *; rewrite Hi; pattern i2 at 2 4 in |- *;
  rewrite (le_Max i1 i2).
 apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62 ].
-elim Hi; trivial with v62.
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith ].
+elim Hi; trivial with arith.
 Qed.
 
 Lemma Decrease_n1n2_l1l2 : i1 = i2 -> Max i1 i2 > Max (Dim l1) (Dim l2).
@@ -478,12 +478,12 @@ rewrite (Choice_right i2 h2 l2).
 pattern i1 at 3 in |- *; rewrite Hi; pattern i2 at 2 4 in |- *;
  rewrite (le_Max i1 i2).
 apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62 ].
-elim Hi; trivial with v62.
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith ].
+elim Hi; trivial with arith.
 Qed.
 
 Lemma Decrease_n1n2_n1h2 : i2 > i1 -> Max i1 i2 > Max i1 (Dim h2).
@@ -494,11 +494,11 @@ rewrite (Choice_left i2 h2 l2).
 rewrite (Choice_invariant (Node i1 h1 l1) i2 Hi true).
 pattern i2 at 2 4 in |- *; rewrite (gt_Max i2 i1 Hi).
 elim (Max_sym i2 i1); apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | rewrite (Max_sym i2 i1); auto with v62 ].
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | rewrite (Max_sym i2 i1); auto with arith ].
 Qed.
 
 Lemma Decrease_n1n2_n1l2 : i2 > i1 -> Max i1 i2 > Max i1 (Dim l2).
@@ -509,11 +509,11 @@ rewrite (Choice_right i2 h2 l2).
 rewrite (Choice_invariant (Node i1 h1 l1) i2 Hi false).
 pattern i2 at 2 4 in |- *; rewrite (gt_Max i2 i1 Hi).
 elim (Max_sym i2 i1); apply Measure_decrease;
- [ trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | trivial with v62
- | apply Dim_node_gt_O; trivial with v62
- | rewrite (Max_sym i2 i1); auto with v62 ].
+ [ trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | trivial with arith
+ | apply Dim_node_gt_O; trivial with arith
+ | rewrite (Max_sym i2 i1); auto with arith ].
 Qed.
 
 End Decrease_induction1.
@@ -539,7 +539,7 @@ Lemma Fun_node_case_left :
  true = A i -> Fun (Node i h l) A = Fun h A.
 Proof.
 intros i h l A.
-simpl in |- *; unfold IF_, F in |- *; simple induction 1; trivial with v62.
+simpl in |- *; unfold IF_, F in |- *; simple induction 1; trivial with arith.
 Qed.
 
 
@@ -548,7 +548,7 @@ Lemma Fun_node_case_right :
  false = A i -> Fun (Node i h l) A = Fun l A.
 Proof.
 intros i h l A.
-simpl in |- *; unfold IF_, F in |- *; simple induction 1; trivial with v62.
+simpl in |- *; unfold IF_, F in |- *; simple induction 1; trivial with arith.
 Qed.
 
 
@@ -564,9 +564,9 @@ simpl in |- *; intros; apply BF_eq_sym; apply eq_f_iff.
 intros j bh H_bh bl H_bl i; simpl in |- *; intro Def_i.
 rewrite <- Def_i.
 elim (Compar j j); intro.
-absurd (j > j); auto with v62. 
+absurd (j > j); auto with arith. 
 apply BF_eq_refl.
-absurd (j > j); auto with v62.
+absurd (j > j); auto with arith.
 Qed.
 
 
@@ -596,12 +596,12 @@ simple induction 1.
 intros.
 apply L_Dep_Var2; simpl in |- *.
 intro b.
-replace FALSE with (Fcst false); auto with v62.
+replace FALSE with (Fcst false); auto with arith.
 (*  Case t=One  *)
 intros.
 apply L_Dep_Var2; simpl in |- *.
 intro b.
-replace TRUE with (Fcst true); auto with v62.
+replace TRUE with (Fcst true); auto with arith.
 (*  Case t=Node(i,th,tl)  *)
 intros th tl HOh Hrec_h HOl Hrec_l i Hil Hih Hneq j Hj.
 apply L_Dep_Var2.
@@ -616,24 +616,24 @@ apply
            else Frestr (Fun tl) j b);
  [ idtac | apply BF_eq_sym; apply Commute_Frestr_IF ].
 apply BF_eq_trans with (f2 := IF F i then Fun th else Fun tl);
- [ auto with v62 | apply BF_eq_congruence_op3 ].
+ [ auto with arith | apply BF_eq_congruence_op3 ].
    (*   (BF_eq (F i) (Frestr (F i) j b)) *)
 pattern (F i) at 1 in |- *.
-elim (Frestr_Fi_j i j) with b; [ trivial with v62 | idtac ].
+elim (Frestr_Fi_j i j) with b; [ trivial with arith | idtac ].
 unfold not in |- *; intro H_absurde.
 simpl in Hj.
 absurd (i > i);
- [ trivial with v62 | pattern i at 1 in |- *; rewrite H_absurde; assumption ].
+ [ trivial with arith | pattern i at 1 in |- *; rewrite H_absurde; assumption ].
    (*   (BF_eq (Fun th) (Frestr (Fun th) j b))  *)
 apply L_Dep_Var1.
 apply Hrec_h.
 simpl in Hj.
-apply gt_trans with i; trivial with v62.
+apply gt_trans with i; trivial with arith.
    (*   (BF_eq (Fun tl) (Frestr (Fun tl) j b))  *)
 apply L_Dep_Var1.
 apply Hrec_l.
 simpl in Hj.
-apply gt_trans with i; trivial with v62.  
+apply gt_trans with i; trivial with arith.  
 Qed.
 
 Remark Fun_sons_dim_nondep :
@@ -643,8 +643,8 @@ Proof.
 intros i h l HO.
 split;
  (apply Dim_is_depvar_max;
-   [ elim (ordered_node_ordered_sons i h l HO); trivial with v62
-   | elim (dim_node_dim_sons i h l HO); trivial with v62 ]).
+   [ elim (ordered_node_ordered_sons i h l HO); trivial with arith
+   | elim (dim_node_dim_sons i h l HO); trivial with arith ]).
 Qed.
 
 Lemma Choice_Fun_eq_Fun_Choice :
@@ -657,17 +657,17 @@ Proof.
 simple induction t.
 (*  t = Zero  *)
 simpl in |- *; intros HO i Hi b.
-replace FALSE with (Fcst false); auto with v62.
+replace FALSE with (Fcst false); auto with arith.
 (*  t = One  *)
 simpl in |- *; intros HO i Hi b.
-replace TRUE with (Fcst true); auto with v62.
+replace TRUE with (Fcst true); auto with arith.
 (*  t = Node(i,h,l)  *)
 intros i h Hrec_h l Hrec_l HO j Hj b.
 simpl in Hj.
 unfold Choice in |- *; elim (Compar j i).
    (* case j > i *)
 intro Hsup.
-apply BF_eq_sym; apply L_Dep_Var1; apply Dim_is_depvar_max; auto with v62.
+apply BF_eq_sym; apply L_Dep_Var1; apply Dim_is_depvar_max; auto with arith.
    (* case j = i *)
 intro Heq; rewrite Heq; simpl in |- *.
 apply
@@ -679,13 +679,13 @@ rewrite Frestr_Fi_i_b.
 elim b; unfold Fcst in |- *; simpl in |- *.
 apply BF_eq_trans with (Frestr (Fun h) i true);
  [ apply BF_eq_sym; apply eq_if_true_f
- | apply BF_eq_sym; apply L_Dep_Var1; trivial with v62 ].
+ | apply BF_eq_sym; apply L_Dep_Var1; trivial with arith ].
 apply BF_eq_trans with (Frestr (Fun l) i false);
  [ apply BF_eq_sym; apply eq_if_false_g
- | apply BF_eq_sym; apply L_Dep_Var1; trivial with v62 ].
+ | apply BF_eq_sym; apply L_Dep_Var1; trivial with arith ].
    (* case j < i *)
 intro Habsurde.
-absurd (i > j); auto with v62.
+absurd (i > j); auto with arith.
 Qed.
 
 Lemma Fun_eq_Fun_choice_eq :
@@ -703,13 +703,13 @@ apply BF_eq_trans with (Frestr (Fun t1) m b).
 apply BF_eq_sym; apply Choice_Fun_eq_Fun_Choice;
  [ assumption
  | rewrite Def_m; unfold Maxdim in |- *; elim (Max_le (Dim t1) (Dim t2));
-    trivial with v62 ].
+    trivial with arith ].
 apply BF_eq_trans with (Frestr (Fun t2) m b).
-apply F_eq_Frestr_eq; trivial with v62.
+apply F_eq_Frestr_eq; trivial with arith.
 apply Choice_Fun_eq_Fun_Choice;
  [ assumption
  | rewrite Def_m; unfold Maxdim in |- *; elim (Max_le (Dim t1) (Dim t2));
-    trivial with v62 ].
+    trivial with arith ].
 Qed.
 
 Lemma Corr_hl_Corr_node :
@@ -730,7 +730,7 @@ apply
   with
     (f2 := IF F i then Op (Fun (Choice b1 i true)) (Fun (Choice b2 i true))
            else Op (Fun (Choice b1 i false)) (Fun (Choice b2 i false))).
-apply BF_eq_congruence_op3; auto with v62.
+apply BF_eq_congruence_op3; auto with arith.
 apply
  BF_eq_trans
   with
@@ -740,7 +740,7 @@ apply
 apply Commute_if_bool_op2; assumption.
 apply BF_eq_congruence_op2; try assumption; apply Shannon_expansion;
  try assumption; rewrite Def_i; unfold Maxdim in |- *;
- elim (Max_le (Dim b1) (Dim b2)); auto with v62.
+ elim (Max_le (Dim b1) (Dim b2)); auto with arith.
 Qed.
 
 

--- a/rauzy/algorithme1/Boolean_functions.v
+++ b/rauzy/algorithme1/Boolean_functions.v
@@ -27,14 +27,14 @@ Definition Ass_eq (A1 A2 : Assign) : Prop := forall i : nat, A1 i = A2 i.
 
 Lemma Ass_eq_refl : forall A : Assign, Ass_eq A A.
 Proof.
-intro A; unfold Ass_eq in |- *; auto with v62.
+intro A; unfold Ass_eq in |- *; auto with arith.
 Qed.
 Hint Resolve Ass_eq_refl.
 
 Lemma Ass_eq_sym : forall A1 A2 : Assign, Ass_eq A1 A2 -> Ass_eq A2 A1.
 Proof.
 intros A1 A2.
-unfold Ass_eq in |- *; auto with v62.
+unfold Ass_eq in |- *; auto with arith.
 Qed.
 Hint Immediate Ass_eq_sym.
 
@@ -43,7 +43,7 @@ Lemma Ass_eq_trans :
 Proof.
 intros A1 A2 A3.
 unfold Ass_eq in |- *; intros H1 H2 i.
-apply trans_equal with (y := A2 i); auto with v62.
+apply trans_equal with (y := A2 i); auto with arith.
 Qed.
  
 (*-----------------------------------------------*)
@@ -56,7 +56,7 @@ Lemma Cases_Assign_i :
  forall (A : Assign) (i : nat), true = A i \/ false = A i.
 Proof.
 intros A i.
-elim (A i); auto with v62.
+elim (A i); auto with arith.
 Qed.
 
 
@@ -76,8 +76,8 @@ Proof.
 intros A i b H.
 apply Extensionality_Assignments.
 unfold Ass_eq, Upd in |- *.
-intro j; elim (eq_nat_dec i j); auto with v62.
-simple induction 1; elim H; trivial with v62.
+intro j; elim (eq_nat_dec i j); auto with arith.
+simple induction 1; elim H; trivial with arith.
 Qed.
 
 
@@ -85,7 +85,7 @@ Lemma L_Assign2 : forall (A : Assign) (i : nat) (b : bool), Upd A i b i = b.
 Proof.
 intros A i b.
 unfold Upd in |- *; elim (eq_nat_dec i i);
- [ trivial with v62 | intro Habs; absurd (i = i); trivial with v62 ].
+ [ trivial with arith | intro Habs; absurd (i = i); trivial with arith ].
 Qed.
 
 
@@ -95,7 +95,7 @@ Lemma L_Assign3 :
 Proof.
 intros A j i Hneq b.
 unfold Upd in |- *; elim (eq_nat_dec j i);
- [ intro Habs; absurd (j = i); assumption | trivial with v62 ].
+ [ intro Habs; absurd (j = i); assumption | trivial with arith ].
 Qed.
 
 
@@ -110,7 +110,7 @@ Definition BF_eq (f1 f2 : BF) : Prop := forall A : Assign, f1 A = f2 A.
 Lemma BF_eq_refl : forall f : BF, BF_eq f f.
 Proof.
 intro f.
-unfold BF_eq in |- *; auto with v62.
+unfold BF_eq in |- *; auto with arith.
 Qed.
 Hint Resolve BF_eq_refl.
 
@@ -118,7 +118,7 @@ Hint Resolve BF_eq_refl.
 Lemma BF_eq_sym : forall f1 f2 : BF, BF_eq f1 f2 -> BF_eq f2 f1.
 Proof.
 intros f1 f2.
-unfold BF_eq in |- *; auto with v62.
+unfold BF_eq in |- *; auto with arith.
 Qed.
 Hint Immediate BF_eq_sym.
 
@@ -129,7 +129,7 @@ Proof.
 intros f1 f2 f3. 
 unfold BF_eq in |- *.
 intros H12 H23 A.
-apply trans_equal with (y := f2 A); auto with v62.
+apply trans_equal with (y := f2 A); auto with arith.
 Qed.
 
 
@@ -159,7 +159,7 @@ intro i.
 unfold BF_eq in |- *.
 intro A.
 unfold IF_, F, TRUE, FALSE in |- *; simpl in |- *.
-elim (A i); auto with v62.
+elim (A i); auto with arith.
 Qed.
 Hint Resolve eq_Fi_if_i.
 
@@ -168,26 +168,26 @@ Lemma eq_f_iff : forall (i : nat) (f : BF), BF_eq f (IF F i then f else f).
 Proof.
 intros i f.
 unfold BF_eq, IF_ in |- *; intro A.
-elim (F i A); trivial with v62.
+elim (F i A); trivial with arith.
 Qed.
 
 
 Lemma eq_if_true_f : forall f g : BF, BF_eq f (IF TRUE then f else g).
 Proof.
-unfold BF_eq in |- *; auto with v62.
+unfold BF_eq in |- *; auto with arith.
 Qed.
 
 
 Lemma eq_if_false_g : forall f g : BF, BF_eq g (IF FALSE then f else g).
 Proof.
-unfold BF_eq in |- *; auto with v62.
+unfold BF_eq in |- *; auto with arith.
 Qed.
 
 
 Lemma TRUE_neutral_AND : forall f : BF, BF_eq (AND TRUE f) f.
 Proof.
 intro f.
-unfold BF_eq, AND in |- *; auto with v62.
+unfold BF_eq, AND in |- *; auto with arith.
 Qed.
 Hint Resolve TRUE_neutral_AND.
 
@@ -195,7 +195,7 @@ Hint Resolve TRUE_neutral_AND.
 Lemma FALSE_absorb_AND : forall f : BF, BF_eq (AND FALSE f) FALSE.
 Proof.
 intro f.
-unfold BF_eq, AND in |- *; auto with v62.
+unfold BF_eq, AND in |- *; auto with arith.
 Qed.
 Hint Resolve FALSE_absorb_AND.
 
@@ -210,7 +210,7 @@ Qed.
 Lemma TRUE_absorb_OR : forall f : BF, BF_eq (OR TRUE f) TRUE.
 Proof.
 intro f.
-unfold BF_eq, OR in |- *; auto with v62.
+unfold BF_eq, OR in |- *; auto with arith.
 Qed.
 Hint Resolve TRUE_absorb_OR.
 
@@ -218,7 +218,7 @@ Hint Resolve TRUE_absorb_OR.
 Lemma FALSE_neutral_OR : forall f : BF, BF_eq (OR FALSE f) f.
 Proof.
 intro f.
-unfold BF_eq, OR in |- *; auto with v62.
+unfold BF_eq, OR in |- *; auto with arith.
 Qed.
 Hint Resolve FALSE_neutral_OR.
 
@@ -250,7 +250,7 @@ Lemma Boolean_AND : Boolean AND.
 Proof.
 unfold Boolean in |- *.
 exists andb.
-unfold AND in |- *; auto with v62.
+unfold AND in |- *; auto with arith.
 Qed.
 Hint Resolve Boolean_AND.
 
@@ -259,7 +259,7 @@ Lemma Boolean_OR : Boolean OR.
 Proof.
 unfold Boolean in |- *.
 exists orb.
-unfold OR in |- *; auto with v62.
+unfold OR in |- *; auto with arith.
 Qed.
 Hint Resolve Boolean_OR.
 
@@ -277,11 +277,11 @@ intro A.
 unfold Boolean in HOp.
 elim HOp.
 intros op Def_op.
-apply trans_equal with (y := op (f1 A) (f2 A)); auto with v62.
-apply trans_equal with (y := op (f'1 A) (f'2 A)); auto with v62.
+apply trans_equal with (y := op (f1 A) (f2 A)); auto with arith.
+apply trans_equal with (y := op (f'1 A) (f'2 A)); auto with arith.
 unfold BF_eq in H1.
 unfold BF_eq in H2.
-elim H1; elim H2; auto with v62.
+elim H1; elim H2; auto with arith.
 Qed.
 
 
@@ -292,7 +292,7 @@ intros f f' H_f_eq_f'.
 unfold BF_eq, NOT in |- *.
 intro A.
 unfold BF_eq in H_f_eq_f'.
-elim (H_f_eq_f' A); auto with v62.
+elim (H_f_eq_f' A); auto with arith.
 Qed.
 
 
@@ -306,7 +306,7 @@ Lemma BF_eq_congruence_op3 :
 Proof.
 unfold BF_eq in |- *.
 intros f1 f'1 H1 f2 f'2 H2 f3 f'3 H3 A.
-unfold IF_ in |- *; elim (H1 A); elim (f1 A); auto with v62.
+unfold IF_ in |- *; elim (H1 A); elim (f1 A); auto with arith.
 Qed.
 
 
@@ -318,7 +318,7 @@ Lemma Commute_if_not :
 Proof.
 intros f g i.
 unfold BF_eq in |- *; intro A.
-unfold IF_, NOT in |- *; simpl in |- *; elim (F i A); auto with v62.
+unfold IF_, NOT in |- *; simpl in |- *; elim (F i A); auto with arith.
 Qed.
 
 
@@ -347,7 +347,7 @@ rewrite
      | true => g1 A
      | false => g2 A
      end)).
-elim (F i A); trivial with v62.
+elim (F i A); trivial with arith.
 Qed.
 
 
@@ -365,7 +365,7 @@ Proof.
 intros f i.
 unfold BF_eq, Frestr, IF_, F in |- *; intro A; simpl in |- *.
 elim (Cases_Assign_i A i); simple induction 1; elim L_Assign1;
- trivial with v62.
+ trivial with arith.
 Qed.
 
 
@@ -374,7 +374,7 @@ Proof.
 intros i b.
 unfold Frestr, Upd, F, Fcst in |- *.
 elim (eq_nat_dec i i);
- [ trivial with v62 | intro H; absurd (i = i); trivial with v62 ].
+ [ trivial with arith | intro H; absurd (i = i); trivial with arith ].
 Qed.
 
 
@@ -383,8 +383,8 @@ Proof.
 intro i.
 unfold Frestr, Upd, F in |- *.
 elim (eq_nat_dec i i);
- [ unfold TRUE in |- *; trivial with v62
- | intro H; absurd (i = i); trivial with v62 ].
+ [ unfold TRUE in |- *; trivial with arith
+ | intro H; absurd (i = i); trivial with arith ].
 Qed.
 
 
@@ -393,8 +393,8 @@ Proof.
 intro i.
 unfold Frestr, Upd, F in |- *.
 elim (eq_nat_dec i i);
- [ unfold FALSE in |- *; trivial with v62
- | intro H; absurd (i = i); trivial with v62 ].
+ [ unfold FALSE in |- *; trivial with arith
+ | intro H; absurd (i = i); trivial with arith ].
 Qed.
 
 
@@ -404,14 +404,14 @@ Proof.
 intros i j H b.
 unfold Frestr, Upd, F in |- *.
 elim (eq_nat_dec j i);
- [ intro Habs; absurd (i = j); auto with v62 | trivial with v62 ].
+ [ intro Habs; absurd (i = j); auto with arith | trivial with arith ].
 Qed.
 
 
 Lemma Restr_Fcst :
  forall (i : nat) (b1 b2 : bool), Frestr (Fcst b1) i b2 = Fcst b1.
 Proof.
-unfold Frestr, Fcst, Upd in |- *; auto with v62.
+unfold Frestr, Fcst, Upd in |- *; auto with arith.
 Qed.
 
 
@@ -422,7 +422,7 @@ Lemma F_eq_Frestr_eq :
 Proof.
 intros f1 f2 H i b.
 unfold BF_eq in H.
-unfold BF_eq, Frestr in |- *; auto with v62.
+unfold BF_eq, Frestr in |- *; auto with arith.
 Qed.
 Hint Resolve F_eq_Frestr_eq.
 
@@ -433,7 +433,7 @@ Lemma Commute_Frestr_IF :
    (IF Frestr f1 i b then Frestr f2 i b else Frestr f3 i b).
 Proof.
 intros f1 f2 f3 i b.
-unfold BF_eq, IF_, Frestr in |- *; trivial with v62.
+unfold BF_eq, IF_, Frestr in |- *; trivial with arith.
 Qed.
 
 
@@ -458,13 +458,13 @@ elim b.
 (*   Case b=true    *)
 apply
  BF_eq_trans with (f2 := IF F i then Frestr f i true else Frestr f i true);
- [ apply BF_eq_congruence_op3; try trivial with v62
+ [ apply BF_eq_congruence_op3; try trivial with arith
  | apply BF_eq_sym; apply eq_f_iff ].
 apply BF_eq_sym; apply Classic; assumption.
 (*   Case b=false   *)
 apply
  BF_eq_trans with (f2 := IF F i then Frestr f i false else Frestr f i false);
- [ apply BF_eq_congruence_op3; try trivial with v62
+ [ apply BF_eq_congruence_op3; try trivial with arith
  | apply BF_eq_sym; apply eq_f_iff ].
 apply Classic; assumption.
 Qed.
@@ -476,7 +476,7 @@ Proof.
 intros f i H.
 unfold Dep_Var in |- *.
 apply P_notnotP.
-apply BF_eq_trans with (f2 := f); auto with v62.
+apply BF_eq_trans with (f2 := f); auto with arith.
 Qed.
 
 Lemma Fcst_no_depvar : forall (i : nat) (b : bool), ~ Dep_Var (Fcst b) i.
@@ -484,7 +484,7 @@ Proof.
 intros i b.
 apply L_Dep_Var2.
 intro b'.
-rewrite (Restr_Fcst i b b'); trivial with v62.
+rewrite (Restr_Fcst i b b'); trivial with arith.
 Qed.
 
 Lemma FB12 :
@@ -503,9 +503,9 @@ intros i f1 Hf1 f2 Hf2 g1 Hg1 g2 Hg2 H.
 split.
 (*    (BF_eq f1 g1)    *)
 apply BF_eq_trans with (f2 := Frestr f1 i true);
- [ apply L_Dep_Var1; trivial with v62 | idtac ].      
+ [ apply L_Dep_Var1; trivial with arith | idtac ].      
 apply BF_eq_trans with (f2 := Frestr g1 i true);
- [ idtac | apply BF_eq_sym; apply L_Dep_Var1; trivial with v62 ].
+ [ idtac | apply BF_eq_sym; apply L_Dep_Var1; trivial with arith ].
 apply
  BF_eq_trans with (f2 := IF TRUE then Frestr f1 i true else Frestr f2 i true);
  [ apply eq_if_true_f | idtac ].
@@ -517,12 +517,12 @@ apply BF_eq_trans with (f2 := Frestr (IF F i then f1 else f2) i true);
  [ apply BF_eq_sym; apply Commute_Frestr_IF | idtac ].
 apply BF_eq_trans with (f2 := Frestr (IF F i then g1 else g2) i true);
  [ idtac | apply Commute_Frestr_IF ].
-apply F_eq_Frestr_eq; trivial with v62.
+apply F_eq_Frestr_eq; trivial with arith.
 (*    (BF_eq f2 g2)    *)
 apply BF_eq_trans with (f2 := Frestr f2 i false);
- [ apply L_Dep_Var1; trivial with v62 | idtac ].
+ [ apply L_Dep_Var1; trivial with arith | idtac ].
 apply BF_eq_trans with (f2 := Frestr g2 i false);
- [ idtac | apply BF_eq_sym; apply L_Dep_Var1; trivial with v62 ]. 
+ [ idtac | apply BF_eq_sym; apply L_Dep_Var1; trivial with arith ]. 
 apply
  BF_eq_trans
   with (f2 := IF FALSE then Frestr f1 i false else Frestr f2 i false);
@@ -536,7 +536,7 @@ apply BF_eq_trans with (f2 := Frestr (IF F i then f1 else f2) i false);
  [ apply BF_eq_sym; apply Commute_Frestr_IF | idtac ].
 apply BF_eq_trans with (f2 := Frestr (IF F i then g1 else g2) i false);
  [ idtac | apply Commute_Frestr_IF ].
-apply F_eq_Frestr_eq; trivial with v62.
+apply F_eq_Frestr_eq; trivial with arith.
 Qed. 
 
 Remark FB12bis :

--- a/rauzy/algorithme1/Canonicity.v
+++ b/rauzy/algorithme1/Canonicity.v
@@ -20,68 +20,68 @@ Require Import Formula_to_BDT.
 Lemma Unique_Zero :
  forall b : BDT, OBDT b -> BF_eq (Fun Zero) (Fun b) -> Zero = b.
 Proof.
-simple induction b; [ trivial with v62 | idtac | idtac ].
-simpl in |- *; intros; absurd (BF_eq TRUE FALSE); auto with v62.
+simple induction b; [ trivial with arith | idtac | idtac ].
+simpl in |- *; intros; absurd (BF_eq TRUE FALSE); auto with arith.
 exact TRUE_neq_FALSE.
 (*   Case b=Node(i,h,l)  *)
 intros i h Hh l Hl HO HF.
 absurd (h = l).
    (*  ~ h=l *)
-apply ordered_node_neq_sons with (i := i); trivial with v62.
+apply ordered_node_neq_sons with (i := i); trivial with arith.
    (*    h=l  *)
-cut (BF_eq (Fun Zero) (IF F i then Fun h else Fun l)); trivial with v62.
+cut (BF_eq (Fun Zero) (IF F i then Fun h else Fun l)); trivial with arith.
 clear HF; intro HF.
 apply trans_equal with Zero.
 symmetry  in |- *; apply Hh.
-elim (ordered_node_ordered_sons i h l HO); trivial with v62.
+elim (ordered_node_ordered_sons i h l HO); trivial with arith.
 apply BF_eq_sym; elim (FB12bis i) with (Fun h) (Fun l) (Fun Zero);
- [ trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
+ [ trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
  | exact (Fcst_no_depvar i false)
- | auto with v62 ].
+ | auto with arith ].
 apply Hl.
-elim (ordered_node_ordered_sons i h l HO); trivial with v62.
+elim (ordered_node_ordered_sons i h l HO); trivial with arith.
 elim (FB12bis i) with (Fun h) (Fun l) (Fun Zero);
- [ auto with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
+ [ auto with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
  | exact (Fcst_no_depvar i false)
- | auto with v62 ].
+ | auto with arith ].
 Qed.
 
 
 Lemma Unique_One :
  forall b : BDT, OBDT b -> BF_eq (Fun One) (Fun b) -> One = b.
 Proof.
-simple induction b; [ idtac | trivial with v62 | idtac ].
-simpl in |- *; intros; absurd (BF_eq TRUE FALSE); auto with v62.
+simple induction b; [ idtac | trivial with arith | idtac ].
+simpl in |- *; intros; absurd (BF_eq TRUE FALSE); auto with arith.
 exact TRUE_neq_FALSE.
 (*   Case b=Node(i,h,l)  *)
 intros i h Hh l Hl HO HF.
 absurd (h = l).
    (*  ~h=l *)
-apply ordered_node_neq_sons with (i := i); trivial with v62.
+apply ordered_node_neq_sons with (i := i); trivial with arith.
    (*   h=l  *)
-cut (BF_eq (Fun One) (IF F i then Fun h else Fun l)); trivial with v62.
+cut (BF_eq (Fun One) (IF F i then Fun h else Fun l)); trivial with arith.
 clear HF. intro HF.
 apply trans_equal with One.
 symmetry  in |- *; apply Hh.
-elim (ordered_node_ordered_sons i h l HO); trivial with v62.
+elim (ordered_node_ordered_sons i h l HO); trivial with arith.
 apply BF_eq_sym; elim (FB12bis i) with (Fun h) (Fun l) (Fun One);
- [ trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
+ [ trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
  | exact (Fcst_no_depvar i true)
- | auto with v62 ].
+ | auto with arith ].
 apply Hl.
-elim (ordered_node_ordered_sons i h l HO); trivial with v62.
+elim (ordered_node_ordered_sons i h l HO); trivial with arith.
 elim (FB12bis i) with (Fun h) (Fun l) (Fun One);
- [ auto with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
- | elim (Fun_sons_dim_nondep i h l); trivial with v62
+ [ auto with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
+ | elim (Fun_sons_dim_nondep i h l); trivial with arith
  | exact (Fcst_no_depvar i true)
- | auto with v62 ].
+ | auto with arith ].
 Qed.
 
 Lemma Choices_eq_bdts_eq :
@@ -113,7 +113,7 @@ apply trans_equal with b1.
    (* h2 = b1 *)
 replace b1 with (Choice b1 i2 true);
  [ idtac
- | symmetry  in |- *; apply Choice_invariant; elim Def_b1; trivial with v62 ].
+ | symmetry  in |- *; apply Choice_invariant; elim Def_b1; trivial with arith ].
 replace h2 with (Choice b2 i2 true).
 rewrite (gt_Max i2 i1 Hi2supi1).
 change
@@ -127,7 +127,7 @@ symmetry  in |- *; elim Def_b2; apply Choice_left.
    (* l2 = b1 *)
 replace b1 with (Choice b1 i2 false);
  [ idtac
- | symmetry  in |- *; apply Choice_invariant; elim Def_b1; trivial with v62 ].
+ | symmetry  in |- *; apply Choice_invariant; elim Def_b1; trivial with arith ].
 replace l2 with (Choice b2 i2 false).
 rewrite (gt_Max i2 i1 Hi2supi1).
 change
@@ -146,7 +146,7 @@ replace h1 with (Choice b1 i1 true).
 replace h2 with (Choice b2 i2 true).
 rewrite (eq_Max i1 i2 H_i1eqi2).
 pattern i2 at 2 in |- *; rewrite (eq_Max i2 i1);
- [ idtac | symmetry  in |- *; trivial with v62 ].
+ [ idtac | symmetry  in |- *; trivial with arith ].
 change
   (Choice b1 (Max (Dim (Node i1 h1 l1)) (Dim (Node i2 h2 l2))) true =
    Choice b2 (Max (Dim (Node i2 h2 l2)) (Dim (Node i1 h1 l1))) true) 
@@ -161,7 +161,7 @@ replace l1 with (Choice b1 i1 false).
 replace l2 with (Choice b2 i2 false).
 rewrite (eq_Max i1 i2 H_i1eqi2).
 pattern i2 at 2 in |- *; rewrite (eq_Max i2 i1);
- [ idtac | symmetry  in |- *; trivial with v62 ].
+ [ idtac | symmetry  in |- *; trivial with arith ].
 change
   (Choice b1 (Max (Dim (Node i1 h1 l1)) (Dim (Node i2 h2 l2))) false =
    Choice b2 (Max (Dim (Node i2 h2 l2)) (Dim (Node i1 h1 l1))) false) 
@@ -179,7 +179,7 @@ apply trans_equal with b2.
    (* h1 = b2 *)
 replace b2 with (Choice b2 i1 true);
  [ idtac
- | symmetry  in |- *; apply Choice_invariant; elim Def_b2; trivial with v62 ].
+ | symmetry  in |- *; apply Choice_invariant; elim Def_b2; trivial with arith ].
 replace h1 with (Choice b1 i1 true).
 rewrite (gt_Max i1 i2 Hi1supi2).
 change
@@ -193,7 +193,7 @@ symmetry  in |- *; elim Def_b1; apply Choice_left.
 symmetry  in |- *.
 replace b2 with (Choice b2 i1 false);
  [ idtac
- | symmetry  in |- *; apply Choice_invariant; elim Def_b2; trivial with v62 ].
+ | symmetry  in |- *; apply Choice_invariant; elim Def_b2; trivial with arith ].
 replace l1 with (Choice b1 i1 false).
 rewrite (gt_Max i1 i2 Hi1supi2).
 change
@@ -226,8 +226,8 @@ clear Ht1 Ht2 t1 t2.
 intros b1 b2 HO1 Hd1 HO2 Hd2 m Def_m Hrec_true Hrec_false H_eq.
 apply Choices_eq_bdts_eq with m; try assumption.
 simple induction b;
- [ apply Hrec_true; apply Fun_eq_Fun_choice_eq; trivial with v62
- | apply Hrec_false; apply Fun_eq_Fun_choice_eq; trivial with v62 ].
+ [ apply Hrec_true; apply Fun_eq_Fun_choice_eq; trivial with arith
+ | apply Hrec_false; apply Fun_eq_Fun_choice_eq; trivial with arith ].
 Qed.
 
 Remark Canonicity_BF :
@@ -253,7 +253,7 @@ intros e t1 t2.
 unfold Sh_tree_of in |- *.
 simple induction 1; intros HO1 HF1.
 simple induction 1; intros HO2 HF2.
-apply Canonicity_BF with (f1 := Fun_Bexp e) (f2 := Fun_Bexp e); auto with v62.
+apply Canonicity_BF with (f1 := Fun_Bexp e) (f2 := Fun_Bexp e); auto with arith.
 Qed.
 
 
@@ -274,7 +274,7 @@ elim (eq_BDT_decidable te One).
 (* Case te = One *)
 intro H_is; left.
 unfold Tautology in |- *.
-elim Def_te; rewrite H_is; simpl in |- *; auto with v62.
+elim Def_te; rewrite H_is; simpl in |- *; auto with arith.
 (* Case te =/= One *)
 intro H_isnot; right.
 unfold Tautology in |- *.
@@ -282,6 +282,6 @@ unfold not in |- *; unfold not in H_isnot.
 intro H_absurd.
 apply H_isnot.
 elim Def_te; intros HO HF.
-apply Canonicity_BF with (f1 := Fun te) (f2 := Fun One); try trivial with v62.
-simpl in |- *; apply BF_eq_trans with (f2 := Fun_Bexp e); auto with v62.
+apply Canonicity_BF with (f1 := Fun te) (f2 := Fun One); try trivial with arith.
+simpl in |- *; apply BF_eq_trans with (f2 := Fun_Bexp e); auto with arith.
 Qed.

--- a/rauzy/algorithme1/Formula_to_BDT.v
+++ b/rauzy/algorithme1/Formula_to_BDT.v
@@ -115,7 +115,7 @@ apply gt_le_trans with (Maxdim (Choice b1 i false) (Choice b2 i false));
  try assumption; elim Def_i; apply Measure_decrease; 
  assumption.
 split; simpl in |- *.
-rewrite Def_i; auto with v62.
+rewrite Def_i; auto with arith.
 apply Corr_hl_Corr_node; assumption.
 Qed.
 
@@ -126,7 +126,7 @@ Lemma And_BDT_Zero_b2 :
  OBDT b3 /\ Dim b3 <= Dim b2 /\ BF_eq (Fun b3) (AND (Fun Zero) (Fun b2))}.
 Proof.
 intro b2.
-exists Zero; auto with v62.
+exists Zero; auto with arith.
 Qed.
 
 
@@ -137,7 +137,7 @@ Lemma And_BDT_One_b2 :
  OBDT b3 /\ Dim b3 <= Dim b2 /\ BF_eq (Fun b3) (AND (Fun One) (Fun b2))}.
 Proof.
 intros b2 H2.
-exists b2; auto with v62.
+exists b2; auto with arith.
 Qed.
 
 
@@ -148,9 +148,9 @@ Lemma And_BDT_b1_Zero :
 Proof.
 intro b1.
 exists Zero.
-split; try split; auto with v62.
+split; try split; auto with arith.
 apply BF_eq_trans with (f2 := AND FALSE (Fun b1)); try apply Commutative_AND;
- auto with v62.
+ auto with arith.
 Qed.
 
 
@@ -162,10 +162,10 @@ Lemma And_BDT_b1_One :
 Proof.
 intros b1 H1.
 exists b1.
-split; try split; auto with v62.
+split; try split; auto with arith.
 simpl in |- *.
 apply BF_eq_trans with (f2 := AND TRUE (Fun b1)); try apply Commutative_AND;
- auto with v62.
+ auto with arith.
 Qed.
 
 
@@ -182,19 +182,19 @@ pattern b1, b2 in |- *; apply Induction1 with (b1 := b1) (b2 := b2);
  try assumption.
 clear H1 b1 H2 b2; intros b2 H2.
 unfold Maxdim in |- *; elim (le_Max (Dim Zero) (Dim b2));
- [ exact (And_BDT_Zero_b2 b2) | auto with v62 ].
+ [ exact (And_BDT_Zero_b2 b2) | auto with arith ].
 clear H1 b1 H2 b2; intros b2 H2.
 unfold Maxdim in |- *; elim (le_Max (Dim One) (Dim b2));
- [ exact (And_BDT_One_b2 b2 H2) | auto with v62 ].
+ [ exact (And_BDT_One_b2 b2 H2) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 H1.
 unfold Maxdim in |- *; elim Max_sym; elim (le_Max (Dim Zero) (Dim b1));
- [ exact (And_BDT_b1_Zero b1) | auto with v62 ].
+ [ exact (And_BDT_b1_Zero b1) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 H1.
 unfold Maxdim in |- *; elim Max_sym; elim (le_Max (Dim One) (Dim b1));
- [ exact (And_BDT_b1_One b1 H1) | auto with v62 ].
+ [ exact (And_BDT_b1_One b1 H1) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 b2 HO1 HD1 HO2 HD2.
 intros i Def_i Htrue Hfalse.
-apply Op2_BDT_overloaded with i; auto with v62.
+apply Op2_BDT_overloaded with i; auto with arith.
 simple induction b; assumption.
 Qed.
 
@@ -210,7 +210,7 @@ elim (And_BDT_overloaded b1 H1 b2 H2).
 intro b3.
 intro H; elim H; intro H3.
 simple induction 1.
-exists b3; auto with v62.
+exists b3; auto with arith.
 Qed.
 
 Lemma Or_BDT_Zero_b2 :
@@ -220,7 +220,7 @@ Lemma Or_BDT_Zero_b2 :
  OBDT b3 /\ Dim b3 <= Dim b2 /\ BF_eq (Fun b3) (OR (Fun Zero) (Fun b2))}.
 Proof.
 intros b2 H2.
-exists b2; auto with v62.
+exists b2; auto with arith.
 Qed.
 
 
@@ -230,7 +230,7 @@ Lemma Or_BDT_One_b2 :
  OBDT b3 /\ Dim b3 <= Dim b2 /\ BF_eq (Fun b3) (OR (Fun One) (Fun b2))}.
 Proof.
 intros b2.
-exists One; auto with v62.
+exists One; auto with arith.
 Qed.
 
 
@@ -242,10 +242,10 @@ Lemma Or_BDT_b1_Zero :
 Proof.
 intros b1 H1.
 exists b1.
-split; try split; auto with v62.
+split; try split; auto with arith.
 simpl in |- *.
 apply BF_eq_trans with (f2 := OR FALSE (Fun b1)); try apply Commutative_OR;
- auto with v62.
+ auto with arith.
 Qed.
 
 
@@ -256,9 +256,9 @@ Lemma Or_BDT_b1_One :
 Proof.
 intro b1.
 exists One.
-split; try split; auto with v62.
+split; try split; auto with arith.
 apply BF_eq_trans with (f2 := OR TRUE (Fun b1)); try apply Commutative_OR;
- auto with v62.
+ auto with arith.
 Qed.
 
 
@@ -275,19 +275,19 @@ pattern b1, b2 in |- *; apply Induction1 with (b1 := b1) (b2 := b2);
  try assumption.
 clear H1 b1 H2 b2; intros b2 H2.
 unfold Maxdim in |- *; elim (le_Max (Dim Zero) (Dim b2));
- [ exact (Or_BDT_Zero_b2 b2 H2) | auto with v62 ].
+ [ exact (Or_BDT_Zero_b2 b2 H2) | auto with arith ].
 clear H1 b1 H2 b2; intros b2 H2.
 unfold Maxdim in |- *; elim (le_Max (Dim One) (Dim b2));
- [ exact (Or_BDT_One_b2 b2) | auto with v62 ].
+ [ exact (Or_BDT_One_b2 b2) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 H1.
 unfold Maxdim in |- *; elim Max_sym; elim (le_Max (Dim Zero) (Dim b1));
- [ exact (Or_BDT_b1_Zero b1 H1) | auto with v62 ].
+ [ exact (Or_BDT_b1_Zero b1 H1) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 H1.
 unfold Maxdim in |- *; elim Max_sym; elim (le_Max (Dim One) (Dim b1));
- [ exact (Or_BDT_b1_One b1) | auto with v62 ].
+ [ exact (Or_BDT_b1_One b1) | auto with arith ].
 clear H1 b1 H2 b2; intros b1 b2 HO1 HD1 HO2 HD2.
 intros i Def_i Htrue Hfalse.
-apply Op2_BDT_overloaded with i; auto with v62.
+apply Op2_BDT_overloaded with i; auto with arith.
 simple induction b; assumption.
 Qed.
 
@@ -303,7 +303,7 @@ elim (Or_BDT_overloaded b1 H1 b2 H2).
 intro b3.
 intro H; elim H; intro H3.
 simple induction 1.
-exists b3; auto with v62.
+exists b3; auto with arith.
 Qed.
 
 
@@ -317,19 +317,19 @@ Proof.
 simple induction t.
 (*  t = Zero *)
 intro Zero_ordered.
-exists One; simpl in |- *; auto with v62.
+exists One; simpl in |- *; auto with arith.
 (*  t = One *)
 intro One_ordered.
-exists Zero; simpl in |- *; auto with v62.
+exists Zero; simpl in |- *; auto with arith.
 (*  t = Node(i,bh,bl) *)
 intros i bh Hrec_bh bl Hrec_bl Node_ordered.
 elim Hrec_bl;
- [ idtac | elim (ordered_node_ordered_sons i bh bl); auto with v62 ].
+ [ idtac | elim (ordered_node_ordered_sons i bh bl); auto with arith ].
 intro tnot_l.
 simple induction 1; intro tnot_l_ordered; simple induction 1;
  intros H_dimtnot_l H_Funtnot_l.
 elim Hrec_bh;
- [ idtac | elim (ordered_node_ordered_sons i bh bl); auto with v62 ]. 
+ [ idtac | elim (ordered_node_ordered_sons i bh bl); auto with arith ]. 
 intro tnot_h.
 simple induction 1; intro tnot_h_ordered; simple induction 1;
  intros H_dimtnot_h H_Funtnot_h.
@@ -339,33 +339,33 @@ elim (eq_BDT_decidable tnot_h tnot_l).
   (* Case Not left= Not right *)
 intro tnot_h_eq_tnot_l.
 exists tnot_h.
-split; try trivial with v62.
+split; try trivial with arith.
 split; simpl in |- *.
 apply gt_le_weak.
-apply gt_le_trans with (m := Dim bh); auto with v62.
-elim (dim_node_dim_sons i bh bl Node_ordered); auto with v62.
+apply gt_le_trans with (m := Dim bh); auto with arith.
+elim (dim_node_dim_sons i bh bl Node_ordered); auto with arith.
 apply BF_eq_sym.
 apply BF_eq_trans with (f2 := IF F i then NOT (Fun bh) else NOT (Fun bl));
  try apply Commute_if_not.
 unfold BF_eq in |- *; intro A.
 unfold BF_eq in H_Funtnot_h.
 unfold BF_eq in H_Funtnot_l.
-unfold IF_ in |- *; elim (F i A); auto with v62.
-rewrite tnot_h_eq_tnot_l; auto with v62.
+unfold IF_ in |- *; elim (F i A); auto with arith.
+rewrite tnot_h_eq_tnot_l; auto with arith.
   (* Case Not left =/= right *)
 intro tnot_h_neq_tnot_l.
 exists (Node i tnot_h tnot_l).
 split.
 apply order_node; try assumption.
 apply gt_le_trans with (m := Dim bh); try assumption.
-elim (dim_node_dim_sons i bh bl Node_ordered); auto with v62.
+elim (dim_node_dim_sons i bh bl Node_ordered); auto with arith.
 apply gt_le_trans with (m := Dim bl); try assumption.
-elim (dim_node_dim_sons i bh bl Node_ordered); auto with v62.
+elim (dim_node_dim_sons i bh bl Node_ordered); auto with arith.
 simpl in |- *; split; try apply le_n.
 apply BF_eq_sym.
 apply BF_eq_trans with (f2 := IF F i then NOT (Fun bh) else NOT (Fun bl));
  try apply Commute_if_not.
-apply BF_eq_congruence_op3; auto with v62.
+apply BF_eq_congruence_op3; auto with arith.
 Qed.
 
 
@@ -377,21 +377,21 @@ intros t Ht.
 elim (Existence_Not_BDT t Ht).
 intro nt.
 simple induction 1; intro nt_ordered; simple induction 1; intros.
-exists nt; auto with v62.
+exists nt; auto with arith.
 Qed.
 
 
 Lemma Shtree_Tr : {T : BDT | Sh_tree_of Tr T}.
 Proof.
 exists One.
-unfold Sh_tree_of in |- *; auto with v62.
+unfold Sh_tree_of in |- *; auto with arith.
 Qed.
 
 
 Lemma Shtree_Fa : {T : BDT | Sh_tree_of Fa T}.
 Proof.
 exists Zero.
-unfold Sh_tree_of in |- *; auto with v62.
+unfold Sh_tree_of in |- *; auto with arith.
 Qed.
 
 
@@ -400,7 +400,7 @@ Lemma Shtree_Var :
 Proof.
 intros i Hi.
 exists (Node i One Zero).
-unfold Sh_tree_of in |- *; simpl in |- *; auto with v62.
+unfold Sh_tree_of in |- *; simpl in |- *; auto with arith.
 (* Use: def OBDT and eq_Fi_if_i *)
 Qed.
 
@@ -422,9 +422,9 @@ elim (And_BDT t1 t1_ordered t2 t2_ordered); intros t3 Def_t3.
 exists t3.
 unfold Sh_tree_of in |- *; simpl in |- *.
 elim Def_t3; intros t3_ordered Funt3_correct.
-split; auto with v62.
-apply BF_eq_trans with (f2 := AND (Fun t1) (Fun t2)); auto with v62.
-apply BF_eq_congruence_op2; auto with v62.
+split; auto with arith.
+apply BF_eq_trans with (f2 := AND (Fun t1) (Fun t2)); auto with arith.
+apply BF_eq_congruence_op2; auto with arith.
 Qed.
 
 
@@ -445,9 +445,9 @@ elim (Or_BDT t1 t1_ordered t2 t2_ordered); intros t3 Def_t3.
 exists t3.
 unfold Sh_tree_of in |- *; simpl in |- *.
 elim Def_t3; intros t3_ordered Funt3_correct.
-split; auto with v62.
-apply BF_eq_trans with (f2 := OR (Fun t1) (Fun t2)); auto with v62.
-apply BF_eq_congruence_op2; auto with v62.
+split; auto with arith.
+apply BF_eq_trans with (f2 := OR (Fun t1) (Fun t2)); auto with arith.
+apply BF_eq_congruence_op2; auto with arith.
 Qed.
 
 
@@ -466,8 +466,8 @@ simple induction 1.
 intros TNot_e_ordered FunTNot_e_correct.
 exists TNot_e.
 unfold Sh_tree_of in |- *; simpl in |- *.
-split; try apply BF_eq_trans with (NOT (Fun Te)); auto with v62.
-apply BF_eq_congruence_op1; auto with v62.
+split; try apply BF_eq_trans with (NOT (Fun Te)); auto with arith.
+apply BF_eq_congruence_op1; auto with arith.
 Qed.
 
                    

--- a/rauzy/algorithme1/Inductions.v
+++ b/rauzy/algorithme1/Inductions.v
@@ -47,7 +47,7 @@ Proof.
 intros P H1 H2 H3 H4 H5.
 simple induction b1; try assumption.
 intros i1 h1 H6 l1 H7.
-simple induction b2; auto with v62.
+simple induction b2; auto with arith.
 Qed.
 
 Lemma BDT_matching2 :
@@ -60,9 +60,9 @@ Lemma BDT_matching2 :
  forall b1 b2 : BDT, P b1 b2.
 Proof.
 intros P H1 H2 H3 H4 H5.
-simple induction b2; auto with v62.
+simple induction b2; auto with arith.
 intros i2 h2 H6 l2 H7.
-elim b1; auto with v62.
+elim b1; auto with arith.
 Qed.
 
 
@@ -110,13 +110,13 @@ Lemma ind1_ind2 :
 Proof.
 intros P b1 HOb1 HDb1 b2 HOb2 HDb2 H_ind1 b.
 apply H_ind1;
- [ unfold R in |- *; apply Measure_decrease; trivial with v62
+ [ unfold R in |- *; apply Measure_decrease; trivial with arith
  | apply Ordered_node_ordered_restr; try assumption;
     elim (Max_le (Dim b1) (Dim b2)); unfold Maxdim in |- *; 
-    auto with v62
+    auto with arith
  | apply Ordered_node_ordered_restr; try assumption;
     elim (Max_le (Dim b1) (Dim b2)); unfold Maxdim in |- *; 
-    auto with v62 ].
+    auto with arith ].
 Qed.
  
 
@@ -143,23 +143,23 @@ apply Wf_ind1.
 clear b1 b2.
 intros b1 b2.
 pattern b1, b2 in |- *.
-apply BDT_matching1; auto with v62.
+apply BDT_matching1; auto with arith.
 clear b1 b2.
 intros i1 i2 h1 h2 l1 l2 Hn1n2 n1_ordered n2_ordered.
 apply H5 with (i := Max i1 i2); try assumption; try apply Dim_node_gt_O;
- try trivial with v62.
+ try trivial with arith.
 (* P(n1\i=true,n2\i=true) *)
 change
   (P (Choice (Node i1 h1 l1) (Maxdim (Node i1 h1 l1) (Node i2 h2 l2)) true)
      (Choice (Node i2 h2 l2) (Maxdim (Node i1 h1 l1) (Node i2 h2 l2)) true))
  in |- *.
-apply ind1_ind2; try assumption; apply Dim_node_gt_O; auto with v62.
+apply ind1_ind2; try assumption; apply Dim_node_gt_O; auto with arith.
 (* P(n1\i=false,n2\i=false) *)
 change
   (P (Choice (Node i1 h1 l1) (Maxdim (Node i1 h1 l1) (Node i2 h2 l2)) false)
      (Choice (Node i2 h2 l2) (Maxdim (Node i1 h1 l1) (Node i2 h2 l2)) false))
  in |- *.
-apply ind1_ind2; try assumption; apply Dim_node_gt_O; auto with v62.
+apply ind1_ind2; try assumption; apply Dim_node_gt_O; auto with arith.
 Qed.
 
 (*---------------        Second formulation       ----------------------*)
@@ -200,45 +200,45 @@ intros P H1 H2 H3 H4 H5 H6 H7 b1 b2.
 pattern b1, b2 in |- *.
 apply Wf_ind1.
 clear b1 b2; intros b1 b2; pattern b1, b2 in |- *.
-apply BDT_matching1; auto with v62.
+apply BDT_matching1; auto with arith.
 intros i1 i2 h1 h2 l1 l2 Hn1n2 Hn1 Hn2.
 elim (Compar i1 i2); intro Hi.
 (* case i1 > i2 *)
-apply H5; auto with v62.
+apply H5; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_h1n2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
  | assumption ].
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_l1n2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
  | assumption ].
 (* case i1 = i2 *)
-apply H6; auto with v62.
+apply H6; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_h1h2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_l1l2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 (* case i2 > i1 *)
-apply H7; auto with v62.
+apply H7; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_n1h2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
  | assumption
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_n1l2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
  | assumption
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 Qed.
 
 
@@ -300,38 +300,38 @@ intros P H1 H2 H3 H4 H5 H6 H7 b1 b2.
 pattern b1, b2 in |- *.
 apply Wf_ind1.
 clear b1 b2; intros b1 b2; pattern b1, b2 in |- *.
-apply BDT_matching2; auto with v62.
+apply BDT_matching2; auto with arith.
 intros i1 i2 h1 h2 l1 l2 Hn1n2 Hn1 Hn2.
 elim (Compar i1 i2); intro Hi.
 (* case i1 > i2 *)
-apply H5; auto with v62.
+apply H5; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_h1n2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
  | assumption ].
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_l1n2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
  | assumption ].
 (* case i1 = i2 *)
-apply H6; auto with v62.
+apply H6; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_h1h2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_l1l2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
- | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with v62
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 Hn1); auto with arith
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 (* case i2 > i1 *)
-apply H7; auto with v62.
+apply H7; auto with arith.
 apply Hn1n2;
  [ unfold R, Maxdim in |- *; simpl in |- *;
     exact (Decrease_n1n2_n1l2 i1 i2 h1 l1 Hn1 h2 l2 Hn2 Hi)
  | assumption
- | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with v62 ].
+ | elim (ordered_node_ordered_sons i2 h2 l2 Hn2); auto with arith ].
 Qed.

--- a/rauzy/algorithmes_2_et_3/Monotony.v
+++ b/rauzy/algorithmes_2_et_3/Monotony.v
@@ -22,13 +22,13 @@ Definition Inf (A1 A2 : Assign) := forall i : nat, A1 i = true -> A2 i = true.
 
 Lemma Inf_refl : forall A : Assign, Inf A A.
 Proof.
-unfold Inf in |- *; auto with v62.
+unfold Inf in |- *; auto with arith.
 Qed.
 
 Lemma Inf_trans :
  forall A1 A2 A3 : Assign, Inf A1 A2 -> Inf A2 A3 -> Inf A1 A3.
 Proof.
-unfold Inf in |- *; auto with v62.
+unfold Inf in |- *; auto with arith.
 Qed.
 
 Lemma Upd_preserves_Inf :
@@ -39,7 +39,7 @@ intros A1 A2 A1_Inf_A2 i b.
 unfold Inf in |- *.
 intro j.
 unfold Inf in A1_Inf_A2.
-unfold Upd in |- *; elim (eq_nat_dec i j); auto with v62.
+unfold Upd in |- *; elim (eq_nat_dec i j); auto with arith.
 Qed.
 
 Lemma Divides_Inf :
@@ -82,8 +82,8 @@ unfold Monotonic in |- *; intro H_f1.
 intros A1 A2 A1_Inf_A2 H1.
 unfold BF_eq in Heq.
 apply trans_equal with (f1 A2);
- [ auto with v62 | apply H_f1 with A1; try assumption ]. 
-apply trans_equal with (f2 A1); auto with v62.
+ [ auto with arith | apply H_f1 with A1; try assumption ]. 
+apply trans_equal with (f2 A1); auto with arith.
 Qed.
 
 
@@ -94,7 +94,7 @@ Proof.
 intros f i b.
 unfold Monotonic, Frestr in |- *; intros f_Mon A1 A2 A1_Inf_A2.
 intro; apply f_Mon with (Upd A1 i b); try assumption.
-apply Upd_preserves_Inf; trivial with v62.
+apply Upd_preserves_Inf; trivial with arith.
 Qed.
 
 Lemma Mon_node_Mon_sons :
@@ -107,12 +107,12 @@ split.
 (*  left  *)
 rewrite (Choice_left i h l).
 apply BF_eq_Mon_Mon with (Frestr (Fun (Node i h l)) i true);
- [ apply Choice_Fun_eq_Fun_Choice; auto with v62
+ [ apply Choice_Fun_eq_Fun_Choice; auto with arith
  | apply Mon_Frestr_Mon; assumption ].
 (*  right *)
 rewrite (Choice_right i h l).
 apply BF_eq_Mon_Mon with (Frestr (Fun (Node i h l)) i false);
- [ apply Choice_Fun_eq_Fun_Choice; auto with v62
+ [ apply Choice_Fun_eq_Fun_Choice; auto with arith
  | apply Mon_Frestr_Mon; assumption ].
 Qed.
 
@@ -124,8 +124,8 @@ unfold BF_eq in |- *; intro A; unfold TRUE in |- *; simpl in |- *.
 elim (Ass_of_well_defined Nil); intros An Def_An.
 unfold Monotonic in H1f.
 apply H1f with An;
- [ apply Anil_lowest; trivial with v62
- | elim (inv_Implicant Nil f H2f); intros Ha Hb; apply Hb; trivial with v62 ].
+ [ apply Anil_lowest; trivial with arith
+ | elim (inv_Implicant Nil f H2f); intros Ha Hb; apply Hb; trivial with arith ].
 Qed.
 
 Lemma Divides_implic_implic :
@@ -141,7 +141,7 @@ intros Ap' Def_Ap'.
 elim (Ass_of_well_defined p); intros Ap Def_Ap.
 unfold Monotonic in Hf; apply Hf with Ap.
 apply Divides_Inf with p p'; try assumption.
-elim (inv_Implicant p f Hp); auto with v62.
+elim (inv_Implicant p f Hp); auto with arith.
 Qed.
 
 Lemma L13 :
@@ -166,11 +166,11 @@ Proof.
 intros i h l HO HM p H1p H2p.
 apply L40 with i l; [ assumption | idtac ].
 apply Divides_implic_implic with p;
- [ assumption | idtac | trivial with v62 | assumption ].
-apply L10; [ apply L11; trivial with v62 | assumption ].
+ [ assumption | idtac | trivial with arith | assumption ].
+apply L10; [ apply L11; trivial with arith | assumption ].
 Qed.
 
 Lemma Fcst_monotonic : forall b : bool, Monotonic (Fcst b).
 Proof.
-unfold Monotonic in |- *; auto with v62.
+unfold Monotonic in |- *; auto with arith.
 Qed.

--- a/rauzy/algorithmes_2_et_3/Operator_W.v
+++ b/rauzy/algorithmes_2_et_3/Operator_W.v
@@ -51,7 +51,7 @@ Lemma LP2 : forall b : BDT, OBDT b -> W_complete b Zero Zero -> b = Zero.
 Proof.
 intros b Hb.
 elim (LT1 b Hb);
- [ simple induction 1; trivial with v62
+ [ simple induction 1; trivial with arith
  | unfold W_complete in |- *; simple induction 1;
     intros solb Def_solb Hcomplete ].
 elim (Hcomplete solb Def_solb (No_implicant_FALSE solb)).
@@ -75,13 +75,13 @@ Lemma b1_W_Zero :
 Proof.
 intros b1 H1.
 exists b1.
-split; [ assumption | split; [ trivial with v62 | split ] ].
+split; [ assumption | split; [ trivial with arith | split ] ].
 (*  sound   *)
 unfold W_sound in |- *.
 intro; split; [ assumption | exact (No_implicant_FALSE p) ].
 (* complete *)
 unfold W_complete in |- *.
-intros p H1p H2p; exists p; auto with v62.
+intros p H1p H2p; exists p; auto with arith.
 Qed.
 
 
@@ -95,7 +95,7 @@ Lemma b1_W_One :
 Proof.
 intros b1 H1.
 exists Zero.
-split; [ trivial with v62 | split; [ trivial with v62 | split ] ].
+split; [ trivial with arith | split; [ trivial with arith | split ] ].
 (*  sound   *)
 unfold W_sound in |- *.
 intros p Habsurde.
@@ -120,7 +120,7 @@ Lemma Zero_W_Node :
 Proof.
 intros i2 h2 l2 HO.
 exists Zero.
-split; [ trivial with v62 | split; [ trivial with v62 | split ] ].
+split; [ trivial with arith | split; [ trivial with arith | split ] ].
 (*  sound   *)
 unfold W_sound in |- *.
 intros p Habsurde.
@@ -145,7 +145,7 @@ Lemma One_W_Node :
 Proof.
 intros i2 h2 l2 HO.
 exists One.
-split; [ trivial with v62 | split; [ trivial with v62 | split ] ].
+split; [ trivial with arith | split; [ trivial with arith | split ] ].
 (*  sound   *)
 unfold W_sound in |- *.
 intros p Def_p; split; try assumption.
@@ -153,14 +153,14 @@ rewrite (Solution_of_One_is_Nil p Def_p).
 unfold not in |- *; intro Habsurde.
 absurd (One = Node i2 h2 l2).
 apply Contra with (Node i2 h2 l2 = One);
- [ auto with v62 | exact (neq_Node_One i2 h2 l2) ].
+ [ auto with arith | exact (neq_Node_One i2 h2 l2) ].
 apply Uniqueness;
- [ trivial with v62
+ [ trivial with arith
  | assumption
  | apply BF_eq_sym; apply Bottom_implicant; assumption ].
 (* complete *)
 unfold W_complete in |- *.
-intros p H1p H2p; exists p; auto with v62.
+intros p H1p H2p; exists p; auto with arith.
 Qed.
 
 
@@ -224,33 +224,33 @@ split.
   (* Dim(bh) <= i1 *)
 apply le_trans with (Dim h1);
  [ assumption
- | apply gt_le_weak; elim (dim_node_dim_sons i1 h1 l1); auto with v62 ].
+ | apply gt_le_weak; elim (dim_node_dim_sons i1 h1 l1); auto with arith ].
 split.
        (* Soundness *)
 unfold W_sound in |- *.
 intros p Def_p; split.
 apply Sol_Right.
-elim (HS_l p); [ auto with v62 | elim Heq; trivial with v62 ].
-elim (HS_h p); [ auto with v62 | elim Heq; trivial with v62 ].
+elim (HS_l p); [ auto with arith | elim Heq; trivial with arith ].
+elim (HS_h p); [ auto with arith | elim Heq; trivial with arith ].
       (* Completeness *)
 unfold W_complete in |- *.
 intros p H1p H2p.
 elim (p_inv_Solution p (Node i1 h1 l1) H1p); intro Hside.
 (*-- Case p Solution of l1 ---*)
 elim (HC_l p Hside H2p); intro p'; simple induction 1; intros H1p' H2p'.
-rewrite Heq; exists p'; auto with v62.
+rewrite Heq; exists p'; auto with arith.
 (*-- Case p=(Cons i1 tlp) --*)
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HC_h tlp Htlp);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
 exists p'; split;
  [ assumption
- | rewrite Def_tlp; apply Divides_trans with tlp; auto with v62 ].
+ | rewrite Def_tlp; apply Divides_trans with tlp; auto with arith ].
 apply L13 with (Cons i1 tlp);
- [ auto with v62
+ [ auto with arith
  | elim Def_tlp; assumption
  | elim Def_tlp; exact (Solution_OBDT_ordered (Node i1 h1 l1) p H1p HO1)
- | trivial with v62 ].
+ | trivial with arith ].
 Qed.
 
 
@@ -278,38 +278,38 @@ split.
         (*  OBDT  *)
 apply order_node; try assumption.
 apply gt_le_trans with (Dim h1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | assumption ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | assumption ].
 apply gt_le_trans with (Dim l1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | assumption ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | assumption ].
 split.
   (* Dim(Node(i1,bh,bl)) <= i1 *)
-auto with v62.
+auto with arith.
 split.
        (* Soundness *)
 unfold W_sound in |- *.
 intros p Def_p.
 elim (p_inv_Solution p (Node i1 bh bl) Def_p); intro Hside.
-elim (HS_l p Hside); auto with v62.
+elim (HS_l p Hside); auto with arith.
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HS_h tlp Htlp); intros H1tlp H2tlp.
-rewrite Def_tlp; split; [ auto with v62 | apply L14; auto with v62 ].
+rewrite Def_tlp; split; [ auto with arith | apply L14; auto with arith ].
       (* Completeness *)
 unfold W_complete in |- *.
 intros p H1p H2p.
 elim (p_inv_Solution p (Node i1 h1 l1) H1p); intro Hside.
 elim (HC_l p Hside H2p); intro p'; simple induction 1; intros H1p' H2p'.
-exists p'; auto with v62. 
+exists p'; auto with arith. 
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HC_h tlp Htlp);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
 exists (Cons i1 p'); split;
- [ auto with v62
- | rewrite Def_tlp; apply Divides_trans with (Cons i1 tlp); auto with v62 ].
+ [ auto with arith
+ | rewrite Def_tlp; apply Divides_trans with (Cons i1 tlp); auto with arith ].
 apply L13 with p;
- [ auto with v62
+ [ auto with arith
  | assumption
  | exact (Solution_OBDT_ordered (Node i1 h1 l1) p H1p HO1)
- | rewrite Def_tlp; trivial with v62 ].
+ | rewrite Def_tlp; trivial with arith ].
 Qed.
 
 
@@ -372,19 +372,19 @@ split.
   (* Dim(bh) <= i1 *)
 apply le_trans with (Dim h1);
  [ assumption
- | apply gt_le_weak; elim (dim_node_dim_sons i1 h1 l1); auto with v62 ].
+ | apply gt_le_weak; elim (dim_node_dim_sons i1 h1 l1); auto with arith ].
 split.
        (* Soundness *)
 unfold W_sound in |- *.
 intros p Def_p; split.
 apply Sol_Right.
-elim (HS_l p); [ auto with v62 | elim Heq_sons; trivial with v62 ].
+elim (HS_l p); [ auto with arith | elim Heq_sons; trivial with arith ].
 apply Contra with (Implicant p (Fun l2));
  [ intro H; apply L5 with i2 h2; try assumption | idtac ].
 elim Heq_dims; apply Gt_dim_out_of_solution with bh; try assumption.
 apply gt_le_trans with (Dim h1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | assumption ].
-elim (HS_l p); [ auto with v62 | elim Heq_sons; assumption ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | assumption ].
+elim (HS_l p); [ auto with arith | elim Heq_sons; assumption ].
       (* Completeness *)
 unfold W_complete in |- *.
 intros p H1p H2p.
@@ -392,28 +392,28 @@ elim (p_inv_Solution p (Node i1 h1 l1) H1p); intro Hside.
 (*-- Case p Solution of l1 ---*)
 elim (HC_l p Hside);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
-rewrite Heq_sons; exists p'; auto with v62.
+rewrite Heq_sons; exists p'; auto with arith.
 apply Contra with (Implicant p (Fun (Node i2 h2 l2)));
  [ intro H; apply L10; try assumption | assumption ].
 elim Heq_dims; apply Gt_dim_out_of_solution with l1;
  [ assumption
- | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with v62
- | elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with arith
+ | elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith ].
 (*-- Case p=(Cons i1 tlp) --*)
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HC_h tlp Htlp);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
 exists p'; split;
  [ assumption
- | rewrite Def_tlp; apply Divides_trans with tlp; auto with v62 ].
+ | rewrite Def_tlp; apply Divides_trans with tlp; auto with arith ].
 apply Contra with (Implicant p (Fun (Node i2 h2 l2)));
- [ intro HC; rewrite Def_tlp; rewrite Heq_dims; apply L2; auto with v62
- | auto with v62 ].
+ [ intro HC; rewrite Def_tlp; rewrite Heq_dims; apply L2; auto with arith
+ | auto with arith ].
 elim Heq_dims; apply gt_le_trans with (Dim h1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith
  | apply Head_of_solution_le_dim;
     [ assumption
-    | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with v62 ] ].
+    | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with arith ] ].
 Qed.
 
 Lemma Node_W_Node_i1_eq_i2_neq :
@@ -440,37 +440,37 @@ split.
         (*  OBDT  *)
 apply order_node; try assumption.
 apply gt_le_trans with (Dim h1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | assumption ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | assumption ].
 apply gt_le_trans with (Dim l1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | assumption ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | assumption ].
 split.
   (* Dim(bh) <= i1 *)
-auto with v62.
+auto with arith.
 split.
        (* Soundness *)
 unfold W_sound in |- *.
 intros p Def_p.
 elim (p_inv_Solution p (Node i1 bh bl) Def_p); intro Hside.
 (*-- Case p Solution of bl --*)
-elim (HS_l p Hside); intros H1p H2p; split; [ auto with v62 | idtac ].
+elim (HS_l p Hside); intros H1p H2p; split; [ auto with arith | idtac ].
 apply Contra with (Implicant p (Fun l2));
  [ intro H; apply L5 with i2 h2; try assumption | assumption ].
 elim Heq_dims; apply Gt_dim_out_of_solution with l1;
  [ assumption
- | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with v62
+ | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with arith
  | apply gt_le_trans with (Dim l1);
-    [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62
-    | trivial with v62 ] ].
+    [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith
+    | trivial with arith ] ].
 (*-- Case p=(Cons i1 tlp) --*)
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HS_h tlp Htlp); intros H1tlp H2tlp.
-rewrite Def_tlp; split; [ auto with v62 | idtac ].
+rewrite Def_tlp; split; [ auto with arith | idtac ].
 rewrite Heq_dims; apply Contra with (Implicant (Cons i2 tlp) (Fun h2));
- [ intro H3tlp; apply L4 with i2 l2; auto with v62 | idtac ].
+ [ intro H3tlp; apply L4 with i2 l2; auto with arith | idtac ].
 apply L14;
- [ elim (ordered_node_ordered_sons i2 h2 l2 HO2); trivial with v62
+ [ elim (ordered_node_ordered_sons i2 h2 l2 HO2); trivial with arith
  | assumption
- | elim (dim_node_dim_sons i2 h2 l2 HO2); trivial with v62 ]. 
+ | elim (dim_node_dim_sons i2 h2 l2 HO2); trivial with arith ]. 
       (* Completeness *)
 unfold W_complete in |- *.
 intros p H1p H2p.
@@ -478,27 +478,27 @@ elim (p_inv_Solution p (Node i1 h1 l1) H1p); intro Hside.
 (*-- Case p Solution of l1 ---*)
 elim (HC_l p Hside);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
-exists p'; auto with v62.
+exists p'; auto with arith.
 apply Contra with (Implicant p (Fun (Node i2 h2 l2)));
  [ intro H; apply L10; try assumption | assumption ].
 elim Heq_dims; apply Gt_dim_out_of_solution with l1;
  [ assumption
- | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with v62
- | elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with arith
+ | elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith ].
 (*-- Case p=(Cons i1 tlp) --*)
 elim Hside; intro tlp; simple induction 1; intros Htlp Def_tlp.
 elim (HC_h tlp Htlp);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
 exists (Cons i1 p'); split;
- [ auto with v62 | rewrite Def_tlp; auto with v62 ].
+ [ auto with arith | rewrite Def_tlp; auto with arith ].
 apply Contra with (Implicant (Cons i2 tlp) (Fun (Node i2 h2 l2)));
- [ intro HC; apply L2; auto with v62
- | pattern i2 at 1 in |- *; elim Heq_dims; elim Def_tlp; auto with v62 ].
+ [ intro HC; apply L2; auto with arith
+ | pattern i2 at 1 in |- *; elim Heq_dims; elim Def_tlp; auto with arith ].
 elim Heq_dims; apply gt_le_trans with (Dim h1);
- [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with v62 | idtac ].
+ [ elim (dim_node_dim_sons i1 h1 l1 HO1); trivial with arith | idtac ].
 apply Head_of_solution_le_dim;
  [ assumption
- | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with v62 ].
+ | elim (ordered_node_ordered_sons i1 h1 l1 HO1); trivial with arith ].
 Qed.
 
 
@@ -547,17 +547,17 @@ elim (Hdef3 p Def_p); intros H1p H2p.
 split; [ assumption | idtac ].
 apply Contra with (Implicant p (Fun l2));
  [ intro H; apply L5 with i2 h2; try assumption | assumption ].
-apply Gt_dim_out_of_solution with (Node i1 h1 l1); auto with v62.
+apply Gt_dim_out_of_solution with (Node i1 h1 l1); auto with arith.
 (* Completeness *)
 unfold W_complete in |- *.
 unfold W_complete in Hdef4.
 intros p H1p H2p.
 elim (Hdef4 p H1p);
  [ intro p'; simple induction 1; intros H1p' H2p' | idtac ].
-exists p'; auto with v62.
+exists p'; auto with arith.
 apply Contra with (Implicant p (Fun (Node i2 h2 l2)));
  [ intro H; apply L10; try assumption | assumption ].
-apply Gt_dim_out_of_solution with (Node i1 h1 l1); auto with v62.
+apply Gt_dim_out_of_solution with (Node i1 h1 l1); auto with arith.
 Qed.
 
 End Greater_i2.

--- a/rauzy/algorithmes_2_et_3/Prelude_Implicants.v
+++ b/rauzy/algorithmes_2_et_3/Prelude_Implicants.v
@@ -28,7 +28,7 @@ Lemma inv_Implicant :
  Implicant p f ->
  Ordered p /\ (forall A : Assign, Assignment_of p A -> f A = true).
 Proof.
-simple induction 1; auto with v62.
+simple induction 1; auto with arith.
 Qed.
 
 Lemma inv_notImplicant :
@@ -39,7 +39,7 @@ Proof.
 intros p f H.
 apply deMorgan_or_not.
 apply Contra with (Implicant p f);
- [ simple induction 1; intros; apply Def_Implicant; trivial with v62
+ [ simple induction 1; intros; apply Def_Implicant; trivial with arith
  | assumption ].
 Qed.
 
@@ -58,7 +58,7 @@ Qed.
 Lemma Implicants_TRUE : forall p : Path, Ordered p -> Implicant p TRUE.
 Proof.
 intros p Hp.
-apply Def_Implicant; auto with v62.
+apply Def_Implicant; auto with arith.
 Qed.
 
 Lemma No_implicant_FALSE : forall p : Path, ~ Implicant p FALSE.
@@ -86,7 +86,7 @@ elim (Ass_of_well_defined p1); intros A1 Def_A1.
 rewrite <-
  (Extensionality_Assignments A1 A2
     (Div_div_ass_eq p1 p2 H12 H21 A1 Def_A1 A2 Def_A2))
- ; auto with v62.
+ ; auto with arith.
 Qed.
 
 Lemma L14 :
@@ -130,7 +130,7 @@ apply Def_Implicant; try assumption.
 intros Ap Def_Ap.
 generalize Def_Ap; unfold Assignment_of in |- *; simple induction 1.
 intros H_in H_out; simpl in |- *; unfold IF_, F in |- *.
-rewrite (H_in i Hi); auto with v62.
+rewrite (H_in i Hi); auto with arith.
 Qed.
 
 Lemma L2 :
@@ -140,17 +140,17 @@ Lemma L2 :
 Proof.
 intros HO p Def_p Hi.
 elim (inv_Implicant p (Fun h) Def_p); intros H1 H2.
-apply Def_Implicant; [ auto with v62 | intros Aip Def_Aip ].
+apply Def_Implicant; [ auto with arith | intros Aip Def_Aip ].
 elim (Ass_of_well_defined p); intros Ap Def_Ap.
 rewrite (Assign_of_cons_eq p Ap Def_Ap i Aip Def_Aip).
 change (Frestr (Fun (Node i h l)) i true Ap = true) in |- *.
-apply (trans_equal (A:=bool)) with (Fun h Ap); [ idtac | auto with v62 ].
+apply (trans_equal (A:=bool)) with (Fun h Ap); [ idtac | auto with arith ].
 pattern h at 2 in |- *; rewrite (Choice_left i h l).
 generalize Ap;
  change
    (BF_eq (Frestr (Fun (Node i h l)) i true)
       (Fun (Choice (Node i h l) i true))) in |- *.
-apply Choice_Fun_eq_Fun_Choice; auto with v62.
+apply Choice_Fun_eq_Fun_Choice; auto with arith.
 Qed.
 
 Lemma L10 :
@@ -163,7 +163,7 @@ apply Def_Implicant; try assumption.
 intros Ap Def_Ap.
 generalize Def_Ap; unfold Assignment_of in |- *; simple induction 1.
 intros H_in H_out; simpl in |- *; unfold IF_, F in |- *.
-rewrite (H_out i Hi); auto with v62.
+rewrite (H_out i Hi); auto with arith.
 Qed.
 
 End Impl_Node.
@@ -185,10 +185,10 @@ intros p Def_p Hi.
 elim (inv_Implicant p (Fun (Node i h l)) Def_p); intros H1 H2.
 apply Def_Implicant; [ assumption | intros Ap Def_Ap ].
 apply (trans_equal (A:=bool)) with (Fun (Node i h l) Ap);
- [ idtac | auto with v62 ].
+ [ idtac | auto with arith ].
 simpl in |- *; unfold IF_, F in |- *.
 unfold Assignment_of in Def_Ap; elim Def_Ap; intros H_in H_out; clear Def_Ap.
-rewrite (H_in i Hi); trivial with v62.
+rewrite (H_in i Hi); trivial with arith.
 Qed.
 
 Lemma L5 :
@@ -199,10 +199,10 @@ intros p Def_p Hi.
 elim (inv_Implicant p (Fun (Node i h l)) Def_p); intros H1 H2.
 apply Def_Implicant; [ assumption | intros Ap Def_Ap ].
 apply (trans_equal (A:=bool)) with (Fun (Node i h l) Ap);
- [ idtac | auto with v62 ].
+ [ idtac | auto with arith ].
 simpl in |- *; unfold IF_, F in |- *.
 unfold Assignment_of in Def_Ap; elim Def_Ap; intros H_in H_out; clear Def_Ap.
-rewrite (H_out i Hi); trivial with v62.
+rewrite (H_out i Hi); trivial with arith.
 Qed.
 
 Hypothesis HO : OBDT (Node i h l).
@@ -218,9 +218,9 @@ elim
 apply Def_Implicant;
  [ apply Ordered_cons_ordered_tail with i; assumption | intros Ap Def_Ap ].
 elim (Ass_of_well_defined (Cons i p)); intros Aip Def_Aip.
-apply (trans_equal (A:=bool)) with (Fun h Aip); [ idtac | auto with v62 ].
+apply (trans_equal (A:=bool)) with (Fun h Aip); [ idtac | auto with arith ].
 apply Cons_of_non_depvar with p i; try assumption.
-elim (Fun_sons_dim_nondep i h l HO); auto with v62.
+elim (Fun_sons_dim_nondep i h l HO); auto with arith.
 Qed.
 
 End Impl_Sons.
@@ -243,6 +243,6 @@ intros Asub Def_Asub.
 elim (Ass_of_well_defined p); intros Ap Def_Ap.
 apply (trans_equal (A:=bool)) with (Fun b Ap);
  [ symmetry  in |- *; apply Sub_of_non_depvar with p i; try assumption
- | auto with v62 ].
+ | auto with arith ].
 apply Dim_is_depvar_max; assumption.
 Qed.

--- a/rauzy/algorithmes_2_et_3/Prelude_Paths.v
+++ b/rauzy/algorithmes_2_et_3/Prelude_Paths.v
@@ -29,7 +29,7 @@ Qed.
 
 Lemma I_of_cons_ip : forall (p : Path) (i : nat), Of i (Cons i p).
 Proof.
-simpl in |- *; auto with v62.
+simpl in |- *; auto with arith.
 Qed.
 Hint Resolve I_of_cons_ip.
 
@@ -37,7 +37,7 @@ Lemma Of_p_of_cons_ip :
  forall (p : Path) (i j : nat), Of j p -> Of j (Cons i p).
 Proof.
 intros p i j.
-unfold Of, Cons in |- *; auto with v62.
+unfold Of, Cons in |- *; auto with arith.
 Qed.
 Hint Resolve Of_p_of_cons_ip.
 
@@ -46,7 +46,7 @@ Lemma Of_cons_ip_of_p :
 Proof.
 intros p i j.
 unfold Of at 1 in |- *; simpl in |- *; simple induction 1;
- [ intro; simple induction 1; assumption | trivial with v62 ].
+ [ intro; simple induction 1; assumption | trivial with arith ].
 Qed.
 
 Lemma Not_of_cons_ip :
@@ -54,22 +54,22 @@ Lemma Not_of_cons_ip :
 Proof.
 intros.
 change (~ (i = j \/ Of j p)) in |- *.
-apply deMorgan_not_or; trivial with v62.
+apply deMorgan_not_or; trivial with arith.
 Qed.
 Hint Resolve Not_of_cons_ip.
 
 Lemma Nil_or_not_Nil : forall p : Path, p = Nil \/ (exists k : nat, Of k p).
 Proof.
 simple induction p.
-auto with v62.
+auto with arith.
 intros a tl H.
-right; exists a; auto with v62.
+right; exists a; auto with arith.
 Qed.
 
 Lemma Empty_is_Nil : forall p : Path, (forall i : nat, ~ Of i p) -> p = Nil.
 Proof.
-intro p; elim (Nil_or_not_Nil p); auto with v62.
-simple induction 1; intros k Hk Hp; absurd (Of k p); auto with v62.
+intro p; elim (Nil_or_not_Nil p); auto with arith.
+simple induction 1; intros k Hk Hp; absurd (Of k p); auto with arith.
 Qed.
 
 
@@ -82,7 +82,7 @@ Definition Divides (p1 p2 : Path) := forall i : nat, Of i p1 -> Of i p2.
 
 Lemma Divides_reflexive : forall p : Path, Divides p p.
 Proof.
-unfold Divides in |- *; auto with v62.
+unfold Divides in |- *; auto with arith.
 Qed.
 Hint Resolve Divides_reflexive.
 
@@ -90,7 +90,7 @@ Hint Resolve Divides_reflexive.
 Lemma Divides_trans :
  forall p1 p2 p3 : Path, Divides p1 p2 -> Divides p2 p3 -> Divides p1 p3.
 Proof.
-unfold Divides in |- *; auto with v62.
+unfold Divides in |- *; auto with arith.
 Qed.
 
 Lemma Divides_p_cons_ip : forall (p : Path) (i : nat), Divides p (Cons i p).
@@ -121,7 +121,7 @@ unfold Divides in |- *.
 intros j Hj.
 elim (H1 j Hj);
  [ intro Habs; absurd (Of j p1); [ elim Habs; assumption | assumption ]
- | trivial with v62 ].
+ | trivial with arith ].
 Qed.
 
 Lemma L80 :
@@ -129,7 +129,7 @@ Lemma L80 :
 Proof.
 intros p1 p2 i.
 unfold Divides in |- *; intros H1 H2.
-apply Contra with (Of i p2); auto with v62.
+apply Contra with (Of i p2); auto with arith.
 Qed.
 
 Lemma Divides_tail_divides_cons :
@@ -138,7 +138,7 @@ Lemma Divides_tail_divides_cons :
 Proof.
 intros p1 p2 i.
 unfold Divides in |- *; intros H1 j; simpl in |- *.
-simple induction 1; auto with v62.
+simple induction 1; auto with arith.
 Qed.
 Hint Resolve Divides_tail_divides_cons.
 
@@ -164,12 +164,12 @@ absurd (Of i nil); try assumption.
 unfold Of in |- *; simpl in |- *; contradiction.
 clear p.
 intros j p Hp i Hi.
-exists p; trivial with v62.
+exists p; trivial with arith.
 Qed.
 
 Lemma Head_of_p_in_p : forall (p : Path) (i : nat), Of i p -> Of (Head p) p.
 Proof.
-simple induction p; [ simpl in |- *; contradiction | auto with v62 ].
+simple induction p; [ simpl in |- *; contradiction | auto with arith ].
 Qed.
 
 
@@ -193,7 +193,7 @@ Definition inv_Ordered (p : Path) :=
 
 Lemma p_inv_Ordered : forall p : Path, Ordered p -> inv_Ordered p.
 Proof.
-simple induction 1; simpl in |- *; auto with v62.
+simple induction 1; simpl in |- *; auto with arith.
 Qed.
 Hint Resolve p_inv_Ordered.
 
@@ -201,7 +201,7 @@ Lemma Ordered_cons_ordered_tail :
  forall (i : nat) (p : Path), Ordered (Cons i p) -> Ordered p.
 Proof.
 intros i p H.
-elim (p_inv_Ordered (Cons i p) H); auto with v62.
+elim (p_inv_Ordered (Cons i p) H); auto with arith.
 Qed.
 
 Lemma L11 : forall (i : nat) (p : Path), Ordered (Cons i p) -> ~ Of i p.
@@ -210,15 +210,15 @@ intro i; simple induction p;
  [ intro; exact (in_nil (a:=i)) | clear p; intros j q Hq H ].
 change (~ (j = i \/ Of i q)) in |- *.
 apply deMorgan_not_or.
-apply Contra with (i = j); [ auto with v62 | apply gt_neq ].
-elim (p_inv_Ordered (Cons i (Cons j q))); auto with v62.
+apply Contra with (i = j); [ auto with arith | apply gt_neq ].
+elim (p_inv_Ordered (Cons i (Cons j q))); auto with arith.
 apply Hq.
 elim (p_inv_Ordered (Cons j q));
  [ intros H1 H2 | apply Ordered_cons_ordered_tail with i; assumption ].
 apply Cons_ordered;
  [ assumption
  | apply gt_trans with j;
-    [ elim (p_inv_Ordered (Cons i (Cons j q))); auto with v62 | assumption ] ].
+    [ elim (p_inv_Ordered (Cons i (Cons j q))); auto with arith | assumption ] ].
 Qed.
 
 Lemma Head_max_of_ordered_path :
@@ -227,8 +227,8 @@ Proof.
 simple induction 1;
  [ simpl in |- *; contradiction | clear H p; intros p Hp Hrec i Hi j Hj ].
 simpl in |- *; simpl in Hj.
-elim Hj; [ simple induction 1; trivial with v62 | intro ].
-apply gt_le_weak; apply gt_le_trans with (Head p); auto with v62.
+elim Hj; [ simple induction 1; trivial with arith | intro ].
+apply gt_le_weak; apply gt_le_trans with (Head p); auto with arith.
 Qed.
 
 Lemma La_4bis :
@@ -238,7 +238,7 @@ Lemma La_4bis :
 Proof.
 intros p Hp i H1i H2i.
 elim (le_lt_or_eq i (Head p) (Head_max_of_ordered_path p Hp i H1i));
- [ intro Habsurde | trivial with v62 ].
+ [ intro Habsurde | trivial with arith ].
 absurd (Of (Head p) p);
  [ apply H2i; apply lt_gt; assumption
  | apply Head_of_p_in_p with i; assumption ].
@@ -252,7 +252,7 @@ Proof.
 intros p1 p2 i H1 H2.
 unfold Divides in |- *; simpl in |- *.
 intros H j Hj.
-elim (H j); [ idtac | trivial with v62 | auto with v62 ].
+elim (H j); [ idtac | trivial with arith | auto with arith ].
 intro Habsurde.
 absurd (Of i p1); [ exact (L11 i p1 H1) | rewrite Habsurde; assumption ].
 Qed.
@@ -266,9 +266,9 @@ absurd (Of i Nil); [ exact (in_nil (a:=i)) | assumption ].
 clear H p; intros p H Hrec i Hi j Hj.
 unfold Of in Hj; elim Hj.
   (* case i=j *)
-simple induction 1; apply gt_le_trans with (Head p); auto with v62.
+simple induction 1; apply gt_le_trans with (Head p); auto with arith.
   (* case j in p *)
-auto with v62.
+auto with arith.
 Qed.
 
 Lemma Pth_ord9 :
@@ -280,16 +280,16 @@ simple induction p2.
   (* case p2=nil *)
 intros.
 apply Cons_ordered;
- [ assumption | apply (Pth_ord8 (Cons i p1) H i); auto with v62 ].
+ [ assumption | apply (Pth_ord8 (Cons i p1) H i); auto with arith ].
   (* case p2=/= nil *)  
 clear p2; intros hp2 tlp2 Hrec Hp2 Hdiv.
 apply Cons_ordered; try assumption.
 apply gt_le_trans with (Head p1);
- [ elim (p_inv_Ordered (Cons i p1) H); auto with v62
+ [ elim (p_inv_Ordered (Cons i p1) H); auto with arith
  | apply Head_max_of_ordered_path ].
-elim (p_inv_Ordered (Cons i p1) H); auto with v62.
+elim (p_inv_Ordered (Cons i p1) H); auto with arith.
 unfold Divides in Hdiv.
-apply Hdiv; apply Head_of_p_in_p with (i := hp2); auto with v62.
+apply Hdiv; apply Head_of_p_in_p with (i := hp2); auto with arith.
 Qed.
 
 Lemma Cons_equal_head_equal :
@@ -303,9 +303,9 @@ Proof.
 intros i1 tl1 HO1 i2 tl2 HO2 Hdiv1 Hdiv2.
 apply le_antisym.
 change (Head (Cons i1 tl1) <= Head (Cons i2 tl2)) in |- *.
-apply Head_max_of_ordered_path; auto with v62.
+apply Head_max_of_ordered_path; auto with arith.
 change (Head (Cons i2 tl2) <= Head (Cons i1 tl1)) in |- *.
-apply Head_max_of_ordered_path; auto with v62.
+apply Head_max_of_ordered_path; auto with arith.
 Qed.
 
 Lemma Ordered_paths_eq :
@@ -316,31 +316,31 @@ Proof.
 simple induction 1; clear H p1.
 simple induction 1; try clear H p2.
 (* case Nil Nil *)
-trivial with v62.
+trivial with arith.
 (* case Nil Cons *)
 intros p1 HO1 Hrec1 i Hi Hdiv1 Hdiv2.
 unfold Divides in Hdiv2.
-absurd (Of i Nil); [ exact (in_nil (a:=i)) | auto with v62 ].
+absurd (Of i Nil); [ exact (in_nil (a:=i)) | auto with arith ].
 intros tl1 HO_tl1 Hrec_tl1 i1 Hi1.
 simple induction 1.
 (* case Cons Nil *)
 intro Hdiv1.
 unfold Divides in Hdiv1.
-absurd (Of i1 Nil); [ exact (in_nil (a:=i1)) | auto with v62 ].
+absurd (Of i1 Nil); [ exact (in_nil (a:=i1)) | auto with arith ].
 (* case Cons Cons *)
 intros tl2 HO_tl2 Hrec_tl2 i2 Hi2 Hdiv1 Hdiv2.
 elim (Hrec_tl1 tl2 HO_tl2).
 elim
  (Cons_equal_head_equal i1 tl1 (Cons_ordered tl1 HO_tl1 i1 Hi1) i2 tl2
     (Cons_ordered tl2 HO_tl2 i2 Hi2) Hdiv1 Hdiv2); 
- trivial with v62.
+ trivial with arith.
 apply (Divides_cons_divides_tail tl1 tl2 i1);
- [ auto with v62
+ [ auto with arith
  | pattern i1 in |- *;
     rewrite
      (Cons_equal_head_equal i1 tl1 (Cons_ordered tl1 HO_tl1 i1 Hi1) i2 tl2
         (Cons_ordered tl2 HO_tl2 i2 Hi2) Hdiv1 Hdiv2)
-     ; auto with v62
+     ; auto with arith
  | pattern i1 at 2 in |- *;
     rewrite
      (Cons_equal_head_equal i1 tl1 (Cons_ordered tl1 HO_tl1 i1 Hi1) i2 tl2
@@ -351,8 +351,8 @@ apply (Divides_cons_divides_tail tl2 tl1 i1);
     rewrite
      (Cons_equal_head_equal i1 tl1 (Cons_ordered tl1 HO_tl1 i1 Hi1) i2 tl2
         (Cons_ordered tl2 HO_tl2 i2 Hi2) Hdiv1 Hdiv2)
-     ; auto with v62
- | auto with v62
+     ; auto with arith
+ | auto with arith
  | pattern i1 at 1 in |- *;
     rewrite
      (Cons_equal_head_equal i1 tl1 (Cons_ordered tl1 HO_tl1 i1 Hi1) i2 tl2
@@ -370,11 +370,11 @@ Proof.
 intros i p HO p' H1 H2 H3.
 elim (Tail_exists p' i H3); intros tl' Def_tl'.
 exists tl'.
-rewrite (La_4bis p' H2 i H3); [ trivial with v62 | intros j Hj ].
+rewrite (La_4bis p' H2 i H3); [ trivial with arith | intros j Hj ].
 unfold not in |- *; intro Habs; absurd (j > i);
  [ unfold Divides in H1; apply le_not_gt | assumption ].
 change (j <= Head (Cons i p)) in |- *; apply Head_max_of_ordered_path;
- auto with v62.
+ auto with arith.
 Qed.
 
 
@@ -409,24 +409,24 @@ Hint Unfold Inv_Solution.
 Lemma p_inv_Solution :
  forall (p : Path) (b : BDT), Solution p b -> Inv_Solution p b.
 Proof.
-simple induction 1; [ auto with v62 | idtac | auto with v62 ].
+simple induction 1; [ auto with arith | idtac | auto with arith ].
 clear H b p.
 intros i h l p Def_p H.
 unfold Inv_Solution in |- *.
-right; exists p; auto with v62.
+right; exists p; auto with arith.
 Qed.
 Hint Resolve p_inv_Solution.
 
 Lemma No_solution_Zero : forall p : Path, ~ Solution p Zero.
 Proof.
 unfold not in |- *; intros p H.
-change (Inv_Solution p Zero) in |- *; auto with v62.
+change (Inv_Solution p Zero) in |- *; auto with arith.
 Qed.
 
 Lemma Solution_of_One_is_Nil : forall p : Path, Solution p One -> p = Nil.
 Proof.
 intros.
-change (Inv_Solution p One) in |- *; auto with v62.
+change (Inv_Solution p One) in |- *; auto with arith.
 Qed.
 
 Lemma L1 :
@@ -435,35 +435,35 @@ Lemma L1 :
  Solution p l \/ (exists p' : Path, Solution p' h /\ p = Cons i p').
 Proof.
 intros i h l p H.
-change (Inv_Solution p (Node i h l)) in |- *; auto with v62.
+change (Inv_Solution p (Node i h l)) in |- *; auto with arith.
 Qed.
 
 Lemma Head_of_solution_le_dim :
  forall (p : Path) (b : BDT), Solution p b -> OBDT b -> Head p <= Dim b.
 Proof.
 simple induction 1;
- [ auto with v62
- | auto with v62
+ [ auto with arith
+ | auto with arith
  | clear H p b; intros i h l p Def_p Hrec HO ].
 apply le_trans with (Dim l);
- [ apply Hrec; elim (ordered_node_ordered_sons i h l HO); auto with v62
- | apply gt_le_weak; elim (dim_node_dim_sons i h l); auto with v62 ].
+ [ apply Hrec; elim (ordered_node_ordered_sons i h l HO); auto with arith
+ | apply gt_le_weak; elim (dim_node_dim_sons i h l); auto with arith ].
 Qed.
 
 Lemma Solution_OBDT_ordered :
  forall (b : BDT) (p : Path), Solution p b -> OBDT b -> Ordered p.
 Proof.
 simple induction 1;
- [ auto with v62
+ [ auto with arith
  | clear H p b; intros i h l p Def_p Hrec Hnode
  | clear H p b; intros i h l p Def_p Hrec Hnode ].
 apply Cons_ordered.
-apply Hrec; elim (ordered_node_ordered_sons i h l Hnode); auto with v62.
+apply Hrec; elim (ordered_node_ordered_sons i h l Hnode); auto with arith.
 apply gt_le_trans with (Dim h);
- [ elim (dim_node_dim_sons i h l); auto with v62
+ [ elim (dim_node_dim_sons i h l); auto with arith
  | apply (Head_of_solution_le_dim p h Def_p);
-    elim (ordered_node_ordered_sons i h l Hnode); auto with v62 ].
-apply Hrec; elim (ordered_node_ordered_sons i h l Hnode); auto with v62.
+    elim (ordered_node_ordered_sons i h l Hnode); auto with arith ].
+apply Hrec; elim (ordered_node_ordered_sons i h l Hnode); auto with arith.
 Qed.
 
 Lemma Gt_dim_out_of_solution :
@@ -472,7 +472,7 @@ Lemma Gt_dim_out_of_solution :
 Proof.
 intros b p Def_p Hb i Hi.
 unfold not in |- *; intro Habsurde.
-absurd (i > i); [ auto with v62 | apply gt_le_trans with (Head p) ].
+absurd (i > i); [ auto with arith | apply gt_le_trans with (Head p) ].
 apply gt_le_trans with (Dim b);
  [ assumption | exact (Head_of_solution_le_dim p b Def_p Hb) ].
 exact
@@ -498,22 +498,22 @@ apply le_trans with (Head p);
 apply Head_max_of_ordered_path;
  [ exact (Solution_OBDT_ordered (Node i h l) p Def_p HO) | idtac ].
 unfold Divides in H3p'; apply H3p'.
-pattern p' at 2 in |- *; rewrite Def_tlp'; trivial with v62.
+pattern p' at 2 in |- *; rewrite Def_tlp'; trivial with arith.
 Qed.
 
 Lemma LT1 :
  forall b : BDT, OBDT b -> b = Zero \/ (exists p : Path, Solution p b).
 Proof.
 simple induction 1;
- [ auto with v62
- | right; exists Nil; trivial with v62
+ [ auto with arith
+ | right; exists Nil; trivial with arith
  | intros l r HOl Hl HOr Hr i H1i H2i Hsons ].
 elim Hr; [ intro Hr0 | simple induction 1; intros sr Def_sr ].
 elim Hl; [ intro Hl0 | simple induction 1; intros sl Def_sl ].
 clear Hl. clear Hr.
-elim Hsons; rewrite Hl0; rewrite Hr0; trivial with v62.
-right; exists (Cons i sl); auto with v62.
-right; exists sr; auto with v62.
+elim Hsons; rewrite Hl0; rewrite Hr0; trivial with arith.
+right; exists (Cons i sl); auto with arith.
+right; exists sr; auto with arith.
 Qed.
 
 
@@ -533,7 +533,7 @@ exists (fun i : nat => false).
 unfold Assignment_of in |- *; split;
  [ intros i Habs; absurd (Of i nil); try assumption; unfold Of in |- *;
     exact (in_nil (a:=i))
- | trivial with v62 ].
+ | trivial with arith ].
 (*  p=Cons(a,l)  *)
 intros a l.
 simple induction 1; intros Al Def_Al; clear H.
@@ -541,7 +541,7 @@ unfold Assignment_of in Def_Al; elim Def_Al; intros HAl1 HAl2; clear Def_Al.
 exists (Upd Al a true).
 unfold Assignment_of in |- *; split.
      (* variables assigned to true *)
-intro i; replace (Of i (a :: l)) with (a = i \/ In i l); trivial with v62.
+intro i; replace (Of i (a :: l)) with (a = i \/ In i l); trivial with arith.
 simple induction 1.
 (* PB Changein Intros i Hi; Change a=i \/ (In nat i l) in Hi.
 Elim Hi; Clear Hi.*)
@@ -555,7 +555,7 @@ elim (eq_nat_dec a i);
     exact (L_Assign3 Al a i adifi (Al i)) ].
      (* variables assigned to false *)
 intro i; replace (~ Of i (a :: l)) with (~ (a = i \/ In i l));
- trivial with v62; intro Hi.
+ trivial with arith; intro Hi.
 elim (deMorgan_and_not (a = i) (In i l) Hi); intros Hi_1 Hi_2; clear Hi.
 rewrite <- (HAl2 i Hi_2).
 exact (L_Assign3 Al a i Hi_1 true).
@@ -579,10 +579,10 @@ unfold Assignment_of in Def_A2; elim Def_A2; intros HA2_in HA2_out;
 unfold Ass_eq in |- *; intro i.
 elim (Of_path_dec p1 i); intro H.
 apply (trans_equal (A:=bool)) with true;
- [ auto with v62 | symmetry  in |- *; auto with v62 ].
+ [ auto with arith | symmetry  in |- *; auto with arith ].
 apply (trans_equal (A:=bool)) with false;
- [ auto with v62 | symmetry  in |- * ].
-apply HA2_out; apply Contra with (Of i p1); auto with v62.
+ [ auto with arith | symmetry  in |- * ].
+apply HA2_out; apply Contra with (Of i p1); auto with arith.
 Qed.
 
 Lemma Assign_of_cons :
@@ -592,7 +592,7 @@ Proof.
 intros p i A.
 unfold Assignment_of in |- *.
 simple induction 1; intros H1 H2; clear H.
-apply H1; unfold Of, Cons in |- *; trivial with v62.
+apply H1; unfold Of, Cons in |- *; trivial with arith.
 Qed.
 
 Lemma Inv_Assignment_of_true :
@@ -604,9 +604,9 @@ unfold Assignment_of in |- *.
 simple induction 1; intros H1 H2; clear H.
 intros i Def_i.
 elim (Of_path_dec p i);
- [ trivial with v62 | intro Habsurde; absurd (A i = false) ].
+ [ trivial with arith | intro Habsurde; absurd (A i = false) ].
 rewrite Def_i; exact diff_true_false.
-auto with v62.
+auto with arith.
 Qed.
 
 Lemma Inv_Assignment_of_false :
@@ -618,10 +618,10 @@ unfold Assignment_of in |- *.
 simple induction 1; intros H1 H2; clear H.
 intros i Def_i.
 elim (Of_path_dec p i);
- [ intro Habsurde; absurd (A i = true) | trivial with v62 ].
+ [ intro Habsurde; absurd (A i = true) | trivial with arith ].
 apply Contra with (true = A i);
- [ auto with v62 | rewrite Def_i; exact diff_true_false ].
-auto with v62.
+ [ auto with arith | rewrite Def_i; exact diff_true_false ].
+auto with arith.
 Qed.
 
 Lemma Assign_of_cons_eq :
@@ -649,9 +649,9 @@ apply (trans_equal (A:=bool)) with true;
  | elim H1; symmetry  in |- *; exact (L_Assign2 A i true) ].
 (*-- (Of j p) /\ ~ i=j --*)
 apply (trans_equal (A:=bool)) with true;
- [ apply HA'_in; auto with v62
+ [ apply HA'_in; auto with arith
  | apply (trans_equal (A:=bool)) with (A j);
-    [ symmetry  in |- *; apply HA_in; trivial with v62
+    [ symmetry  in |- *; apply HA_in; trivial with arith
     | symmetry  in |- *; exact (L_Assign3 A i j H1 true) ] ].
 (*-- ~(Of j p) /\ i=j --*)
 apply (trans_equal (A:=bool)) with true;
@@ -659,9 +659,9 @@ apply (trans_equal (A:=bool)) with true;
  | elim H1; symmetry  in |- *; exact (L_Assign2 A i true) ].
 (*-- ~(Of j p) /\ ~ i=j --*)
 apply (trans_equal (A:=bool)) with false;
- [ apply HA'_out; auto with v62
+ [ apply HA'_out; auto with arith
  | apply (trans_equal (A:=bool)) with (A j);
-    [ symmetry  in |- *; apply HA_out; trivial with v62
+    [ symmetry  in |- *; apply HA_out; trivial with arith
     | symmetry  in |- *; exact (L_Assign3 A i j H1 true) ] ].
 Qed.
 
@@ -675,7 +675,7 @@ intros p A Def_A i A' Def_A' f Hi.
 rewrite (Assign_of_cons_eq p A Def_A i A' Def_A'). 
 change (f A = Frestr f i true A) in |- *.
 generalize A; change (BF_eq f (Frestr f i true)) in |- *.
-apply L_Dep_Var1; trivial with v62.    
+apply L_Dep_Var1; trivial with arith.    
 Qed.
 
 
@@ -698,9 +698,9 @@ Definition Sub (p : Path) (i : nat) : Path :=
 Lemma I_out_of_Sub_ip : forall (p : Path) (i : nat), ~ Of i (Sub p i).
 Proof.
 simple induction p.
-simpl in |- *; unfold not in |- *; trivial with v62.
+simpl in |- *; unfold not in |- *; trivial with arith.
 clear p; intros a p Hp i; simpl in |- *.
-elim (eq_nat_dec i a); auto with v62.
+elim (eq_nat_dec i a); auto with arith.
 Qed.
 Hint Resolve I_out_of_Sub_ip.
 
@@ -715,7 +715,7 @@ apply Hp; try assumption.
 apply Of_cons_ip_of_p with i; try assumption.
 rewrite H; assumption.
 simpl in |- *; simpl in H1j.
-elim H1j; auto with v62.
+elim H1j; auto with arith.
 Qed.
 Hint Resolve jofp_jofsub_ip.
 
@@ -728,7 +728,7 @@ clear p; intros a p Hp i j; simpl in |- *.
 elim (eq_nat_dec i a);
  [ intros; right; apply Hp with i; assumption
  | intro; simpl in |- *; simple induction 1;
-    [ auto with v62 | intro; right; apply Hp with i; assumption ] ].
+    [ auto with arith | intro; right; apply Hp with i; assumption ] ].
 Qed.
 
 Lemma Outof_p_outof_sub_ip :
@@ -743,26 +743,26 @@ Lemma Head_sub_ordered :
  forall p : Path, Ordered p -> forall i : nat, Head (Sub p i) <= Head p.
 Proof.
 simple induction 1;
- [ simpl in |- *; trivial with v62
+ [ simpl in |- *; trivial with arith
  | clear H p; intros p H1p H2p i Hi j; simpl in |- * ].
 elim (eq_nat_dec j i); intro Cas.
 (* case i=j *)
-apply le_trans with (Head p); auto with v62.
+apply le_trans with (Head p); auto with arith.
 (* case i=/=j *)
-auto with v62.
+auto with arith.
 Qed.
 
 Lemma Ordered_p_ordered_sub_pi :
  forall (i : nat) (p : Path), Ordered p -> Ordered (Sub p i).
 Proof.
 intro i; simple induction p;
- [ simpl in |- *; trivial with v62 | intros hp tlp Hrec Hp ].
+ [ simpl in |- *; trivial with arith | intros hp tlp Hrec Hp ].
 simpl in |- *; elim (eq_nat_dec i hp); intro Cas.
 apply Hrec; apply Ordered_cons_ordered_tail with hp; assumption.
 apply Cons_ordered;
  [ apply Hrec; apply Ordered_cons_ordered_tail with hp; assumption
  | apply gt_le_trans with (Head tlp) ].
-elim (p_inv_Ordered (Cons hp tlp) Hp); auto with v62.
+elim (p_inv_Ordered (Cons hp tlp) Hp); auto with arith.
 apply Head_sub_ordered; apply Ordered_cons_ordered_tail with hp; assumption.
 Qed.
 
@@ -776,7 +776,7 @@ Proof.
 intros p i A.
 unfold Assignment_of in |- *.
 simple induction 1; intros H1 H2; clear H.
-apply H2; auto with v62.
+apply H2; auto with arith.
 Qed.
 
 Lemma Assign_of_sub_eq :
@@ -805,9 +805,9 @@ apply (trans_equal (A:=bool)) with false;
  | elim H1; symmetry  in |- *; exact (L_Assign2 A i false) ].
 (*-- (Of j p) /\ ~ i=j --*)
 apply (trans_equal (A:=bool)) with true;
- [ apply HA'_in; auto with v62
+ [ apply HA'_in; auto with arith
  | apply (trans_equal (A:=bool)) with (A j);
-    [ symmetry  in |- *; apply HA_in; trivial with v62
+    [ symmetry  in |- *; apply HA_in; trivial with arith
     | symmetry  in |- *; exact (L_Assign3 A i j H1 false) ] ].
 (*-- ~(Of j p) /\ i=j --*)
 apply (trans_equal (A:=bool)) with false;
@@ -815,9 +815,9 @@ apply (trans_equal (A:=bool)) with false;
  | elim H1; symmetry  in |- *; exact (L_Assign2 A i false) ].
 (*-- ~(Of j p) /\ ~ i=j --*)
 apply (trans_equal (A:=bool)) with false;
- [ apply HA'_out; auto with v62
+ [ apply HA'_out; auto with arith
  | apply (trans_equal (A:=bool)) with (A j);
-    [ symmetry  in |- *; apply HA_out; trivial with v62
+    [ symmetry  in |- *; apply HA_out; trivial with arith
     | symmetry  in |- *; exact (L_Assign3 A i j H1 false) ] ].
 Qed.
 
@@ -831,5 +831,5 @@ intros p A Def_A i A' Def_A' f Hi.
 rewrite (Assign_of_sub_eq p A Def_A i A' Def_A'). 
 change (f A = Frestr f i false A) in |- *.
 generalize A; change (BF_eq f (Frestr f i false)) in |- *.
-apply L_Dep_Var1; trivial with v62.    
+apply L_Dep_Var1; trivial with arith.    
 Qed.

--- a/rauzy/algorithmes_2_et_3/Prelude_Primes.v
+++ b/rauzy/algorithmes_2_et_3/Prelude_Primes.v
@@ -29,14 +29,14 @@ Lemma Prime_implicant :
  forall (p : Path) (f : BF), Prime p f -> Implicant p f.
 Proof.
 unfold Prime in |- *.
-simple induction 1; auto with v62.
+simple induction 1; auto with arith.
 Qed.
 Hint Resolve Prime_implicant.
 
 Lemma Prime_ordered : forall (p : Path) (f : BF), Prime p f -> Ordered p.
 Proof.
 intros p f Hp.
-elim (inv_Implicant p f (Prime_implicant p f Hp)); auto with v62.
+elim (inv_Implicant p f (Prime_implicant p f Hp)); auto with arith.
 Qed.
 
 Lemma No_prime_FALSE : forall p : Path, ~ Prime p FALSE.
@@ -51,7 +51,7 @@ Lemma Nil_prime_of_TRUE : Prime Nil TRUE.
 Proof.
 unfold Prime in |- *.
 split;
- [ apply Implicants_TRUE; trivial with v62
+ [ apply Implicants_TRUE; trivial with arith
  | intros p H1p H2p; exact (Nil_divides_all p) ].
 Qed.
 
@@ -62,7 +62,7 @@ unfold Prime in |- *.
 simple induction 1; intros H1 H2; clear H.
 apply (incl_nil_eq nat); change (Divides p Nil) in |- *.
 apply H2;
- [ apply Implicants_TRUE; trivial with v62 | exact (Nil_divides_all p) ].
+ [ apply Implicants_TRUE; trivial with arith | exact (Nil_divides_all p) ].
 Qed.
 
 
@@ -73,9 +73,9 @@ Lemma Vars_prime_le_dim :
  OBDT b -> forall p : Path, Prime p (Fun b) -> Head p <= Dim b.
 Proof.
 intros b HO p Hp.
-elim (le_or_lt (Head p) (Dim b)); [ trivial with v62 | intro Habsurde ].
+elim (le_or_lt (Head p) (Dim b)); [ trivial with arith | intro Habsurde ].
 elim (Nil_or_not_Nil p);
- [ intro H; rewrite H; auto with v62 | simple induction 1; intros i Hi ].
+ [ intro H; rewrite H; auto with arith | simple induction 1; intros i Hi ].
 absurd (Of (Head p) p); [ idtac | exact (Head_of_p_in_p p i Hi) ].
 apply Contra with (Of (Head p) (Sub p (Head p)));
  [ idtac | exact (I_out_of_Sub_ip p (Head p)) ].
@@ -109,9 +109,9 @@ Proof.
 intros i h l HO p Def_p.
 apply Cons_ordered;
  [ exact (Prime_ordered p (Fun h) Def_p) | apply gt_le_trans with (Dim h) ].
-elim (dim_node_dim_sons i h l HO); auto with v62.
+elim (dim_node_dim_sons i h l HO); auto with arith.
 apply Vars_prime_le_dim;
- [ elim (ordered_node_ordered_sons i h l HO); auto with v62 | assumption ].
+ [ elim (ordered_node_ordered_sons i h l HO); auto with arith | assumption ].
 Qed.
 
 
@@ -135,7 +135,7 @@ unfold not in |- *; intros j H1j H2j.
 absurd (Of j (Sub p j));
  [ exact (I_out_of_Sub_ip p j) | unfold Divides at 2 in H2 ].
 apply H2;
- [ apply L14bis; auto with v62
+ [ apply L14bis; auto with arith
  | unfold Divides in |- *; exact (Of_sub_pi_of_p p j)
  | assumption ].
 Qed.
@@ -165,7 +165,7 @@ elim (Tail_exists p i Hi); intros p' Def_p'.
 exists p'; split; [ rewrite (Lc_4bis Def_p Hi); assumption | idtac ]. 
 rewrite (Lc_4bis Def_p Hi).
 rewrite <- Def_p'. 
-elim (inv_Implicant p (Fun (Node i h l)) H1); auto with v62.
+elim (inv_Implicant p (Fun (Node i h l)) H1); auto with arith.
 Qed.
 
 Remark Le_4bis :
@@ -176,7 +176,7 @@ Remark Le_4bis :
 Proof.
 intros p1 Hp p' H1p' H2p'.
 apply Cons_ordered;
- [ elim (inv_Implicant p' (Fun h) H1p'); auto with v62 | idtac ].
+ [ elim (inv_Implicant p' (Fun h) H1p'); auto with arith | idtac ].
 elim (Nil_or_not_Nil p').
      (* Case p'=Nil *)
 intro Def_p'; rewrite Def_p'; simpl in |- *.
@@ -184,9 +184,9 @@ exact (Dim_node_gt_O i h l HO).
     (* Case p'=/=Nil *)
 simple induction 1; intros k Def_k.
 apply gt_le_trans with (Head p1).
-elim (p_inv_Ordered (Cons i p1) Hp); auto with v62.
+elim (p_inv_Ordered (Cons i p1) Hp); auto with arith.
 apply Head_max_of_ordered_path.
-elim (p_inv_Ordered (Cons i p1) Hp); auto with v62.
+elim (p_inv_Ordered (Cons i p1) Hp); auto with arith.
 unfold Divides in H2p'.
 apply H2p'.
 apply Head_of_p_in_p with k; assumption.
@@ -204,10 +204,10 @@ clear Def_p; intro Def_p.
 elim (Ld_4bis Def_p Hi).
 intros p' Hp'.
 elim Hp'; intros Def_p' H.
-exists p'; split; [ elim Hp'; auto with v62 | idtac ].
+exists p'; split; [ elim Hp'; auto with arith | idtac ].
 unfold Prime in |- *; split.
 (*--- (Implicant p' (Fun h)) ---*)
-apply L40 with i l; [ auto with v62 | idtac ].
+apply L40 with i l; [ auto with arith | idtac ].
 rewrite <- Def_p'; assumption.
 (*--- p' least implicant of (Fun h) ---*)
 intros p'' H1p'' H2p''.
@@ -216,10 +216,10 @@ apply Divides_cons_divides_tail with i; [ assumption | idtac | idtac ].
 exact (Le_4bis p' H p'' H1p'' H2p'').
 (* (Divides (Cons i p') (Cons i p'')) *)
 elim Def_p'; apply H2.
-apply L2; auto with v62.
+apply L2; auto with arith.
 elim (p_inv_Ordered (Cons i p'') (Le_4bis p' H p'' H1p'' H2p''));
- auto with v62.
-rewrite Def_p'; apply Divides_tail_divides_cons; trivial with v62.
+ auto with arith.
+rewrite Def_p'; apply Divides_tail_divides_cons; trivial with arith.
 Qed.
 
 Lemma L5bis : Prime p (Fun (Node i h l)) -> ~ Of i p -> Prime p (Fun l).
@@ -229,7 +229,7 @@ unfold Prime in Def_p; elim Def_p; intros H1 H2; clear Def_p.
 unfold Prime in |- *; split;
  [ apply L5 with i h; assumption | intros p' H1p' H2p' ].
 apply H2;
- [ apply L10; [ apply L80 with p; trivial with v62 | assumption ]
+ [ apply L10; [ apply L80 with p; trivial with arith | assumption ]
  | assumption ].
 Qed.
 
@@ -241,13 +241,13 @@ unfold Prime in Def_p; elim Def_p; intros H1 H2; clear Def_p.
 absurd (Of i p).
 (*  ~(Of i p)  *)
 apply L11.
-elim (inv_Implicant (Cons i p) (Fun (Node i h l)) H1); auto with v62.
+elim (inv_Implicant (Cons i p) (Fun (Node i h l)) H1); auto with arith.
 (*   (Of i p)  *) 
 unfold Divides at 2 in H2.
-apply H2; [ idtac | unfold Divides in |- *; auto with v62 | auto with v62 ].
-apply L10; auto with v62.
+apply H2; [ idtac | unfold Divides in |- *; auto with arith | auto with arith ].
+apply L10; auto with arith.
 apply L11.
-elim (inv_Implicant (Cons i p) (Fun (Node i h l)) H1); auto with v62.
+elim (inv_Implicant (Cons i p) (Fun (Node i h l)) H1); auto with arith.
 Qed.
 
 End Node_to_Sons.
@@ -271,9 +271,9 @@ split.
   (* p Implicant of Fun(Node) *)
 apply (L10 i h l p); try assumption.
 apply (Dim_highest_var_of_prime l);
- [ elim (ordered_node_ordered_sons i h l HO); auto with v62
- | unfold Prime in |- *; auto with v62
- | elim (dim_node_dim_sons i h l HO); auto with v62 ].
+ [ elim (ordered_node_ordered_sons i h l HO); auto with arith
+ | unfold Prime in |- *; auto with arith
+ | elim (dim_node_dim_sons i h l HO); auto with arith ].
   (* p smallest *)
 intros p' H1p' H2p'.
 apply H2p; try assumption.
@@ -281,9 +281,9 @@ apply (L5 i h l p' H1p').
 apply Contra with (Of i p);
  [ unfold Divides in H2p'; exact (H2p' i) | idtac ].
 apply (Dim_highest_var_of_prime l);
- [ elim (ordered_node_ordered_sons i h l HO); auto with v62
- | unfold Prime in |- *; auto with v62
- | elim (dim_node_dim_sons i h l HO); auto with v62 ].
+ [ elim (ordered_node_ordered_sons i h l HO); auto with arith
+ | unfold Prime in |- *; auto with arith
+ | elim (dim_node_dim_sons i h l HO); auto with arith ].
 Qed.
 
 Lemma Prime_h_prime_node :
@@ -297,10 +297,10 @@ unfold Prime in |- *; split.
 (* Implicant *)
 apply (L2 i h l HO p H1p_impl).
 apply gt_le_trans with (Dim h);
- [ elim (dim_node_dim_sons i h l HO); trivial with v62
+ [ elim (dim_node_dim_sons i h l HO); trivial with arith
  | apply Vars_prime_le_dim ].
-elim (ordered_node_ordered_sons i h l); auto with v62.
-unfold Prime in |- *; auto with v62.
+elim (ordered_node_ordered_sons i h l); auto with arith.
+unfold Prime in |- *; auto with arith.
 (* smallest *)
 intros p' H1p' H2p'.
 elim (Of_path_dec p' i); intro Cas.
@@ -308,16 +308,16 @@ elim (Of_path_dec p' i); intro Cas.
 elim (Ordered_divisor_of_cons_ip i p) with p';
  [ intros tl' Def_tl'
  | apply (Prime_h_cons_ip_ordered i h l HO); unfold Prime in |- *;
-    auto with v62
+    auto with arith
  | assumption
- | elim (inv_Implicant p' (Fun (Node i h l)) H1p'); auto with v62
+ | elim (inv_Implicant p' (Fun (Node i h l)) H1p'); auto with arith
  | assumption ].
 rewrite Def_tl'; apply Divides_tail_divides_cons.
 apply H1p_min;
  [ apply (L40 i h l HO); elim Def_tl'; assumption
  | apply Divides_cons_divides_tail with i ].
-elim Def_tl'; elim (inv_Implicant p' (Fun (Node i h l)) H1p'); auto with v62.
-apply (Prime_h_cons_ip_ordered i h l HO); unfold Prime in |- *; auto with v62.
+elim Def_tl'; elim (inv_Implicant p' (Fun (Node i h l)) H1p'); auto with arith.
+apply (Prime_h_cons_ip_ordered i h l HO); unfold Prime in |- *; auto with arith.
 elim Def_tl'; assumption.
   (*-- i not in p' --*)
 absurd (Implicant p (Fun l));
@@ -325,7 +325,7 @@ absurd (Implicant p (Fun l));
 assumption.
 exact (L5 i h l p' H1p' Cas).
 exact (L8 p' p i H2p' Cas).
-elim (inv_Implicant p (Fun h) H1p_impl); auto with v62.
+elim (inv_Implicant p (Fun h) H1p_impl); auto with arith.
 Qed.
 
 End Sons_to_Node.
@@ -335,7 +335,7 @@ Lemma Prime_exists :
 Proof.
 simple induction 1.
 (* b=Zero *)
-simple induction 1; trivial with v62.
+simple induction 1; trivial with arith.
 (* b=One  *)
 intro H1; exists Nil; simpl in |- *; exact Nil_prime_of_TRUE.
 (* b=Node *)
@@ -346,19 +346,19 @@ elim (eq_BDT_decidable bl Zero); intro Cas_bl.
 elim (eq_BDT_decidable bh Zero); intro Cas_bh.
       (*-- bh=Zero --*) 
 absurd (bh = bl);
- [ assumption | rewrite Cas_bh; rewrite Cas_bl; trivial with v62 ].
+ [ assumption | rewrite Cas_bh; rewrite Cas_bl; trivial with arith ].
       (*-- bh=/=Zero --*)
 elim (Hrec_bh Cas_bh); intros ph Def_ph. 
 exists (Cons i ph).
 apply (Prime_h_prime_node i bh bl) with (p := ph);
- [ auto with v62
+ [ auto with arith
  | assumption
  | rewrite Cas_bl; simpl in |- *; exact (Fcst_monotonic false)
  | rewrite Cas_bl; simpl in |- *; exact (No_implicant_FALSE ph) ].
   (*-- bl=/=Zero --*)
 elim (Hrec_bl Cas_bl); intros pl Def_pl. 
 exists pl.
-apply (Prime_l_prime_node i bh bl) with (p := pl); auto with v62. 
+apply (Prime_l_prime_node i bh bl) with (p := pl); auto with arith. 
 Qed.
 
 

--- a/rauzy/algorithmes_2_et_3/Primes.v
+++ b/rauzy/algorithmes_2_et_3/Primes.v
@@ -49,7 +49,7 @@ Proof.
 intros p1 b1 Def_p1 b2 b3 Def_b3 p Def_p.
 unfold W_sound in Def_b3.
 unfold Sound in Def_p1.
-apply Def_p1; elim (Def_b3 p Def_p); trivial with v62.
+apply Def_p1; elim (Def_b3 p Def_p); trivial with arith.
 Qed.
 
 
@@ -73,7 +73,7 @@ Lemma Zero_complete : forall b : BDT, OBDT b -> Complete b Zero -> b = Zero.
 Proof.
 intros b Hb.
 elim (eq_BDT_decidable b Zero); intro Cas.
-elim Cas; trivial with v62.
+elim Cas; trivial with arith.
 unfold Complete in |- *; intro H.
 elim (Prime_exists b Hb Cas); intros p Def_p.
 absurd (Solution p Zero); [ exact (No_solution_Zero p) | exact (H p Def_p) ].
@@ -115,7 +115,7 @@ unfold Sound in |- *.
 intros p Def_p; unfold Prime in |- *.
 split.
 apply Implicants_TRUE.
-apply Solution_OBDT_ordered with One; trivial with v62.
+apply Solution_OBDT_ordered with One; trivial with arith.
 intros p' H1_p' H2_p'.
 rewrite (Solution_of_One_is_Nil p Def_p).
 exact (Nil_divides_all p').
@@ -170,36 +170,36 @@ Lemma Result_Ordered :
  Correct l pl -> Correct r pr -> W_correct pl r w -> OBDT (Node i w pr).
 Proof.
 intros HCpl HCpr HCw.
-apply order_node; auto with v62.
+apply order_node; auto with arith.
 apply gt_le_trans with (Dim l);
- [ elim (dim_node_dim_sons i l r); auto with v62
- | apply le_trans with (Dim pl); auto with v62 ].
+ [ elim (dim_node_dim_sons i l r); auto with arith
+ | apply le_trans with (Dim pl); auto with arith ].
 apply gt_le_trans with (Dim r);
- [ elim (dim_node_dim_sons i l r); auto with v62 | auto with v62 ].
+ [ elim (dim_node_dim_sons i l r); auto with arith | auto with arith ].
 (*---- ~w=pr -----*)
 unfold not in |- *; intro Habsurde.
 elim (LT1 w HOw); intro Hcas.
    (* Case w = Zero  *)
-absurd (OBDT (Node i l r)); auto with v62.
+absurd (OBDT (Node i l r)); auto with arith.
 apply Contra with (l = r);
- [ intro H; clear H | apply ordered_node_neq_sons with i; auto with v62 ].
+ [ intro H; clear H | apply ordered_node_neq_sons with i; auto with arith ].
 apply (trans_equal (A:=BDT)) with Zero.
 apply Zero_complete;
- [ elim (ordered_node_ordered_sons i l r HO); trivial with v62 | idtac ].
-elim (LP2 pl HOpl); [ elim HCpl; auto with v62 | idtac ].
+ [ elim (ordered_node_ordered_sons i l r HO); trivial with arith | idtac ].
+elim (LP2 pl HOpl); [ elim HCpl; auto with arith | idtac ].
 pattern Zero at 2 in |- *; elim Hcas.
 elim (Zero_complete r);
- [ elim HCw; trivial with v62
- | elim (ordered_node_ordered_sons i l r HO); trivial with v62
- | elim Hcas; rewrite Habsurde; elim HCpr; trivial with v62 ].
+ [ elim HCw; trivial with arith
+ | elim (ordered_node_ordered_sons i l r HO); trivial with arith
+ | elim Hcas; rewrite Habsurde; elim HCpr; trivial with arith ].
 symmetry  in |- *; apply Zero_complete;
- [ elim (ordered_node_ordered_sons i l r HO); trivial with v62
- | elim Hcas; rewrite Habsurde; elim HCpr; trivial with v62 ].
+ [ elim (ordered_node_ordered_sons i l r HO); trivial with arith
+ | elim Hcas; rewrite Habsurde; elim HCpr; trivial with arith ].
    (* Case w=/=Zero *)
 elim Hcas; intros p Def_p. 
 absurd (Implicant p (Fun r)). 
 elim HCw; unfold W_sound in |- *; intros HCSw HCCw.
-elim (HCSw p Def_p); trivial with v62.
+elim (HCSw p Def_p); trivial with arith.
 apply Prime_implicant.
 elim HCpr; unfold Sound in |- *; intros HCSpr HCCpr.
 apply HCSpr; elim Habsurde; assumption.
@@ -215,19 +215,19 @@ intros HSpl HSpr HSw p Def_p.
 unfold Sound in HSpr.
 unfold Prime in |- *; split.
 (*  Implicant *)
-apply L10; [ idtac | auto with v62 ].
-apply Gt_dim_out_of_solution with pr; [ assumption | auto with v62 | idtac ].
+apply L10; [ idtac | auto with arith ].
+apply Gt_dim_out_of_solution with pr; [ assumption | auto with arith | idtac ].
 apply gt_le_trans with (Dim r);
- [ elim (dim_node_dim_sons i l r HO); trivial with v62 | auto with v62 ].
+ [ elim (dim_node_dim_sons i l r HO); trivial with arith | auto with arith ].
 (*  Smallest  *)
 intros p' H1p' H2p'.
 elim (HSpr p Def_p); intros Hp_Impl Hp_Smallest. 
 apply Hp_Smallest; [ idtac | assumption ].
 apply (L5 i l r p' H1p').
 apply L80 with p; [ assumption | idtac ].
-apply Gt_dim_out_of_solution with pr; [ assumption | auto with v62 | idtac ].
+apply Gt_dim_out_of_solution with pr; [ assumption | auto with arith | idtac ].
 apply gt_le_trans with (Dim r);
- [ elim (dim_node_dim_sons i l r HO); trivial with v62 | auto with v62 ].
+ [ elim (dim_node_dim_sons i l r HO); trivial with arith | auto with arith ].
 Qed.
 
 Lemma Soundness_left_impl :
@@ -242,10 +242,10 @@ rewrite Def_p; apply (L2 i l r HO tl).
 apply Prime_implicant.
 exact (LC2_S_fac1 pl l HSpl r w HSw tl Def_tl).
 apply gt_le_trans with (Dim w);
- [ idtac | apply Head_of_solution_le_dim; auto with v62 ].
+ [ idtac | apply Head_of_solution_le_dim; auto with arith ].
 apply gt_le_trans with (Dim l);
- [ elim (dim_node_dim_sons i l r HO); trivial with v62
- | apply le_trans with (Dim pl); auto with v62 ].
+ [ elim (dim_node_dim_sons i l r HO); trivial with arith
+ | apply le_trans with (Dim pl); auto with arith ].
 Qed.
 
 
@@ -255,10 +255,10 @@ Proof.
 intros tl Def_tl.
 apply Cons_ordered; [ exact (Solution_OBDT_ordered w tl Def_tl HOw) | idtac ].
 apply gt_le_trans with (Dim l);
- [ elim (dim_node_dim_sons i l r HO); trivial with v62
+ [ elim (dim_node_dim_sons i l r HO); trivial with arith
  | apply le_trans with (Dim w);
     [ exact (Head_of_solution_le_dim tl w Def_tl HOw)
-    | apply le_trans with (Dim pl); auto with v62 ] ].
+    | apply le_trans with (Dim pl); auto with arith ] ].
 Qed.
 
 
@@ -282,8 +282,8 @@ rewrite Def_p.
 elim (Tail_exists_with_dim_head i w pr) with p p';
  [ intros tl' Def_p'; rewrite Def_p'
  | exact (Result_Ordered HCpl HCpr HCw)
- | rewrite Def_p; auto with v62
- | elim (inv_Implicant p' (Fun (Node i l r)) H1p'); auto with v62
+ | rewrite Def_p; auto with arith
+ | elim (inv_Implicant p' (Fun (Node i l r)) H1p'); auto with arith
  | assumption
  | assumption ].
 apply Divides_tail_divides_cons;
@@ -291,7 +291,7 @@ apply Divides_tail_divides_cons;
 apply H2tl; [ apply (L40 i l r HO tl'); elim Def_p'; assumption | idtac ].
 apply Divides_cons_divides_tail with i;
  [ elim Def_p'; elim (inv_Implicant p' (Fun (Node i l r)) H1p');
-    trivial with v62
+    trivial with arith
  | exact (Soundness_left_smallest_order tl Def_tl)
  | elim Def_p'; elim Def_p; assumption ].
 Qed.
@@ -316,7 +316,7 @@ elim HCw; intros HCSw HCCw.
 intros p' H1p' H2p' Hi.
 absurd (Implicant tl (Fun r)).
 unfold W_sound in HCSw.
-elim (HCSw tl Def_tl); trivial with v62.
+elim (HCSw tl Def_tl); trivial with arith.
 apply (L9 p');
  [ apply (L8 p' tl i); [ elim Def_p; assumption | assumption ]
  | idtac
@@ -328,7 +328,7 @@ apply H2tl;
 apply (L15 i l r HO Hmon); [ idtac | exact (L5 i l r p' H1p' Hi) ].
 apply (Pth_ord9 i tl);
  [ exact (Soundness_left_smallest_order tl Def_tl)
- | elim (inv_Implicant p' (Fun (Node i l r)) H1p'); trivial with v62
+ | elim (inv_Implicant p' (Fun (Node i l r)) H1p'); trivial with arith
  | apply (L8 p' tl i); [ elim Def_p; assumption | assumption ] ].
 Qed.
 
@@ -405,7 +405,7 @@ elim (LC2_C_fac1 pl l HCCpl r w HCCw tl H2tl);
 elim (Ordered_paths_eq tl' (Solution_OBDT_ordered w tl' H1tl' HOw) tl);
  [ exact H1tl'
  | elim (inv_Implicant tl (Fun l) (Prime_implicant tl (Fun l) H2tl));
-    trivial with v62
+    trivial with arith
  | exact H2tl'
  | idtac ]. 
 elim H2tl; intros H2tl_impl H2tl_smallest; clear H2tl.
@@ -452,34 +452,34 @@ intros.
 (*---- if b1 = Zero  then b2 = Zero ----*)
 exists Zero.
 split;
- [ trivial with v62 | split; [ trivial with v62 | exact BDT2_of_Zero ] ].
+ [ trivial with arith | split; [ trivial with arith | exact BDT2_of_Zero ] ].
 intros.
 (*---- if b1 = One  then b2 = One  ----*)
 exists One.
-split; [ trivial with v62 | split; [ trivial with v62 | exact BDT2_of_One ] ].
+split; [ trivial with arith | split; [ trivial with arith | exact BDT2_of_One ] ].
 (*---- if b1 = (Node i1 h1 l1) then  .... *)
 intros i1 l1 Hrec_l1 r1 Hrec_r1 Node_orded Node_monotonic.
 elim Hrec_l1;
  [ intros Prm_l1 Def_Prm_l1; clear Hrec_l1
- | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with v62
+ | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with arith
  | elim (Mon_node_Mon_sons i1 l1 r1 Node_orded Node_monotonic);
-    trivial with v62 ].
+    trivial with arith ].
 elim Def_Prm_l1; intro HO_Prm_l1.
 simple induction 1; intros HD_Prm_l1 HCorr_Prm_l1; clear H.
 elim Hrec_r1;
  [ intros Prm_r1 Def_Prm_r1; clear Hrec_r1
- | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with v62
+ | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with arith
  | elim (Mon_node_Mon_sons i1 l1 r1 Node_orded Node_monotonic);
-    trivial with v62 ].
+    trivial with arith ].
 elim Def_Prm_r1; intro HO_Prm_r1.
 simple induction 1; intros HD_Prm_r1 HCorr_Prm_r1; clear H.
 clear Def_Prm_r1; clear Def_Prm_l1.
 elim (Existence_Op_W Prm_l1 r1);
  [ intros Prm_l1_W_r1 Correctness_W
  | assumption
- | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with v62
+ | elim (ordered_node_ordered_sons i1 l1 r1 Node_orded); trivial with arith
  | elim (Mon_node_Mon_sons i1 l1 r1 Node_orded Node_monotonic);
-    trivial with v62 ].
+    trivial with arith ].
 elim Correctness_W; intro HO_Prm_l1_W_r1.
 simple induction 1; intros HD_Prm_l1_W_r1 HCorr_Prm_l1_W_r1; clear H.
 clear Correctness_W.
@@ -490,7 +490,7 @@ exact
     HD_Prm_l1 HD_Prm_r1 Prm_l1_W_r1 HO_Prm_l1_W_r1 HD_Prm_l1_W_r1
     HCorr_Prm_l1 HCorr_Prm_r1 HCorr_Prm_l1_W_r1).
 split;
- [ auto with v62
+ [ auto with arith
  | exact
     (Correctness i1 l1 r1 Node_orded Prm_l1 Prm_r1 HO_Prm_l1 HO_Prm_r1
        HD_Prm_l1 HD_Prm_r1 Prm_l1_W_r1 HO_Prm_l1_W_r1 HD_Prm_l1_W_r1


### PR DESCRIPTION
This was as simple as:

```
$ for f in */*/*.v; do sed -e "s/with v62/with arith/g" $f > ${f}_new; mv ${f}_new $f; done
```

(using with arith systematically because lots of proofs fail without it).
